### PR TITLE
初步支持罗马音注音

### DIFF
--- a/src/strange_uta_game/backend/application/auto_check_service.py
+++ b/src/strange_uta_game/backend/application/auto_check_service.py
@@ -70,15 +70,6 @@ _TYPE_FLAG_MAP: Dict[CharType, str] = {
 # 小型假名集合（不含促音 っ/ッ，促音由独立的 check_sokuon 标志控制）
 _SMALL_KANA_SET = frozenset("ぁぃぅぇぉゃゅょゎァィゥェォャュョヮゕゖ")
 
-# 罗马音模式下禁止自动删除的注音类型（删除后无法转换）
-_ROMAJI_PROTECTED_DELETE_TYPES = frozenset({
-    "hiragana",
-    "katakana",
-    "katakana_hiragana_ruby",
-    "katakana_english_ruby",
-    "kanji",
-})
-
 
 def _has_latin(s: str) -> bool:
     """是否含有 ASCII 英文字母（用于词边界判定）。"""
@@ -312,11 +303,6 @@ class AutoCheckService:
         converted = romanize_ruby_parts(texts, particle_indices=particle_indices)
         for part, text in zip(refs, converted):
             part.text = text
-
-    def filter_delete_ruby_types(self, type_names: List[str]) -> List[str]:
-        if not self._romanize_ruby:
-            return list(type_names)
-        return [n for n in type_names if n not in _ROMAJI_PROTECTED_DELETE_TYPES]
 
     def _apply_english_dictionary(
         self, text: str, ruby_results: List[RubyResult], dict_covered: set
@@ -1463,6 +1449,7 @@ class AutoCheckService:
         only_noruby: bool = False,
         apply_user_dict: bool = True,
         restrict_indices: Optional[set] = None,
+        skip_romanize: bool = False,
     ) -> None:
         """分析并应用自动检查结果到句子
 
@@ -1668,7 +1655,21 @@ class AutoCheckService:
         if apply_user_dict and self._dict:
             self._apply_user_dictionary_to_sentence(sentence)
 
-        self._romanize_sentence_ruby(sentence)
+        if not skip_romanize:
+            self._romanize_sentence_ruby(sentence)
+
+    def romanize_project_rubies(self, project: Project) -> int:
+        """对项目所有句子执行罗马音转换（供外部在 delete 之后调用）。"""
+        if not self._romanize_ruby:
+            return 0
+        changed = 0
+        for sentence in project.sentences:
+            before = sum(len(part.text) for ch in sentence.characters if ch.ruby for part in ch.ruby.parts)
+            self._romanize_sentence_ruby(sentence)
+            after = sum(len(part.text) for ch in sentence.characters if ch.ruby for part in ch.ruby.parts)
+            if before != after:
+                changed += 1
+        return changed
 
     def _apply_user_dictionary_to_sentence(self, sentence: Sentence) -> None:
         """Phase 5：把用户词典以子串严格匹配方式覆盖到 sentence.characters 上。
@@ -1815,42 +1816,28 @@ class AutoCheckService:
         only_noruby: bool = False,
         apply_user_dict: bool = True,
         progress_callback=None,
+        skip_romanize: bool = False,
     ) -> None:
-        """分析并应用到整个项目
-
-        Args:
-            project: 项目
-            split_config: 拆分配置
-            keep_existing_timetags: 是否保留现有时间标签
-            only_noruby: 仅对未注音字符应用
-            apply_user_dict: 是否执行 Phase 5 用户词典覆盖（默认 True）。
-                传 False 时推迟词典覆盖，由调用方在删除注音后手动调用
-                :meth:`apply_user_dict_to_project`。
-            progress_callback: 可选回调 (current: int, total: int)，每处理完一行后调用。
-        """
+        """分析并应用到整个项目"""
         sentences = project.sentences
         total = len(sentences)
         for i, sentence in enumerate(sentences):
             self.apply_to_sentence(
                 sentence, split_config, keep_existing_timetags, only_noruby,
-                apply_user_dict=apply_user_dict,
+                apply_user_dict=apply_user_dict, skip_romanize=skip_romanize,
             )
             if progress_callback is not None:
                 progress_callback(i + 1, total)
-
-        # check_count 变更后，自动顺延越界的选中 cp
         project.shift_selected_checkpoint_if_lost()
 
-    def apply_user_dict_to_project(self, project: Project) -> None:
-        """对整个项目执行 Phase 5 用户词典覆盖。
-
-        供调用方在按类型删除注音之后单独调用，确保用户词典覆盖在删除之后生效。
-        """
+    def apply_user_dict_to_project(self, project: Project, skip_romanize: bool = False) -> None:
+        """对整个项目执行 Phase 5 用户词典覆盖。"""
         if not self._dict:
             return
         for sentence in project.sentences:
             self._apply_user_dictionary_to_sentence(sentence)
-            self._romanize_sentence_ruby(sentence)
+            if not skip_romanize:
+                self._romanize_sentence_ruby(sentence)
 
     def update_checkpoints_from_rubies(
         self,
@@ -2154,15 +2141,6 @@ def get_kanji_linked_indices(characters: list) -> set:
 def _ruby_is_all_hiragana(ruby_text: str) -> bool:
     """注音文本是否全为平假名（范围 U+3040-U+309F）。"""
     return bool(ruby_text) and all("぀" <= c <= "ゟ" for c in ruby_text)
-
-
-def filter_delete_ruby_types_for_romaji(
-    type_names: List[str], romanize_ruby: bool
-) -> List[str]:
-    """过滤删除注音类型列表（模块级辅助，供 worker/home 等无 service 实例处调用）。"""
-    if not romanize_ruby:
-        return list(type_names)
-    return [n for n in type_names if n not in _ROMAJI_PROTECTED_DELETE_TYPES]
 
 
 def delete_rubies_by_type_names(

--- a/src/strange_uta_game/backend/application/auto_check_service.py
+++ b/src/strange_uta_game/backend/application/auto_check_service.py
@@ -38,6 +38,9 @@ from strange_uta_game.backend.infrastructure.parsers.english_ruby import (
 from strange_uta_game.backend.infrastructure.parsers.e2k_engine import (
     EnglishToKanaEngine,
 )
+from strange_uta_game.backend.infrastructure.parsers.romaji import (
+    romanize_ruby_parts,
+)
 
 
 # 允许自动注音的字符类型白名单（第十批 #5）：
@@ -66,6 +69,15 @@ _TYPE_FLAG_MAP: Dict[CharType, str] = {
 
 # 小型假名集合（不含促音 っ/ッ，促音由独立的 check_sokuon 标志控制）
 _SMALL_KANA_SET = frozenset("ぁぃぅぇぉゃゅょゎァィゥェォャュョヮゕゖ")
+
+# 罗马音模式下禁止自动删除的注音类型（删除后无法转换）
+_ROMAJI_PROTECTED_DELETE_TYPES = frozenset({
+    "hiragana",
+    "katakana",
+    "katakana_hiragana_ruby",
+    "katakana_english_ruby",
+    "kanji",
+})
 
 
 def _has_latin(s: str) -> bool:
@@ -200,6 +212,7 @@ class AutoCheckService:
         self._chinese_mode = chinese_mode
         self._analyzer = ruby_analyzer or (None if chinese_mode else create_analyzer())
         self._flags = auto_check_flags or {}
+        self._romanize_ruby = bool(self._flags.get("romanize_ruby", False))
         self._annotate_katakana_with_english = annotate_katakana_with_english
         # 用户词典：保留词典数组顺序（上方条目优先级最高）。
         # 在 apply_to_sentence 末尾以子串严格匹配方式覆盖 Character[]，
@@ -232,6 +245,78 @@ class AutoCheckService:
                 self._kanji_dict = json.loads(dict_path.read_text(encoding="utf-8"))
         except Exception:
             pass
+
+    def _should_make_romaji_self_ruby(self, char: str) -> bool:
+        if not self._romanize_ruby or len(char) != 1:
+            return False
+        return get_char_type(char) in (
+            CharType.HIRAGANA, CharType.KATAKANA, CharType.SOKUON, CharType.LONG_VOWEL)
+
+    def _detect_romaji_particles(self, sentence: Sentence) -> set[int]:
+        if not self._romanize_ruby:
+            return set()
+        particle_indices: set[int] = set()
+        part_idx = 0
+        for char_idx, ch in enumerate(sentence.characters):
+            if not ch.ruby:
+                continue
+            for part in ch.ruby.parts:
+                text = part.text
+                if len(text) != 1 or text != ch.char:
+                    part_idx += 1
+                    continue
+                if text == "\u3092":
+                    particle_indices.add(part_idx)
+                    part_idx += 1
+                    continue
+                if text not in ("\u306f", "\u3078"):
+                    part_idx += 1
+                    continue
+                if char_idx == 0:
+                    part_idx += 1
+                    continue
+                prev = sentence.characters[char_idx - 1]
+                prev_ct = get_char_type(prev.char) if len(prev.char) == 1 else CharType.OTHER
+                if prev_ct not in (CharType.KANJI, CharType.HIRAGANA, CharType.KATAKANA,
+                                   CharType.SOKUON, CharType.LONG_VOWEL):
+                    part_idx += 1
+                    continue
+                if char_idx + 1 >= len(sentence.characters):
+                    particle_indices.add(part_idx)
+                    part_idx += 1
+                    continue
+                next_ch = sentence.characters[char_idx + 1]
+                next_ct = get_char_type(next_ch.char) if len(next_ch.char) == 1 else CharType.OTHER
+                if next_ct == CharType.KANJI:
+                    particle_indices.add(part_idx)
+                elif next_ct not in (CharType.HIRAGANA, CharType.KATAKANA,
+                                     CharType.SOKUON, CharType.LONG_VOWEL):
+                    particle_indices.add(part_idx)
+                part_idx += 1
+        return particle_indices
+
+    def _romanize_sentence_ruby(self, sentence: Sentence) -> None:
+        if not self._romanize_ruby:
+            return
+        refs: List[RubyPart] = []
+        texts: List[str] = []
+        for ch in sentence.characters:
+            if not ch.ruby:
+                continue
+            for part in ch.ruby.parts:
+                refs.append(part)
+                texts.append(part.text)
+        if not refs:
+            return
+        particle_indices = self._detect_romaji_particles(sentence)
+        converted = romanize_ruby_parts(texts, particle_indices=particle_indices)
+        for part, text in zip(refs, converted):
+            part.text = text
+
+    def filter_delete_ruby_types(self, type_names: List[str]) -> List[str]:
+        if not self._romanize_ruby:
+            return list(type_names)
+        return [n for n in type_names if n not in _ROMAJI_PROTECTED_DELETE_TYPES]
 
     def _apply_english_dictionary(
         self, text: str, ruby_results: List[RubyResult], dict_covered: set
@@ -1479,8 +1564,9 @@ class AutoCheckService:
             # Stage 0: result.ruby 为 List[str]（来自 _group_reading_for_character），
             # 映射为 Ruby(parts=[RubyPart(text=s), ...])。
             ruby_groups = result.ruby  # List[str] | None
-            if ruby_groups and not (
-                len(ruby_groups) == 1 and ruby_groups[0] == result.char
+            if ruby_groups and (
+                self._romanize_ruby
+                or not (len(ruby_groups) == 1 and ruby_groups[0] == result.char)
             ):
                 # 处理 rubyPart 数量 > checkCount 的情况
                 from strange_uta_game.backend.infrastructure.parsers.inline_format import (
@@ -1582,6 +1668,8 @@ class AutoCheckService:
         if apply_user_dict and self._dict:
             self._apply_user_dictionary_to_sentence(sentence)
 
+        self._romanize_sentence_ruby(sentence)
+
     def _apply_user_dictionary_to_sentence(self, sentence: Sentence) -> None:
         """Phase 5：把用户词典以子串严格匹配方式覆盖到 sentence.characters 上。
 
@@ -1675,12 +1763,13 @@ class AutoCheckService:
                         ch.check_count = len(parts)
                     else:
                         ch.ruby = None
-                        # 无 parts 时：汉字或被 linked（连词块内）→ cp=0；
-                        # 其他情况保留主流程默认值（如假名默认 cp=1）。
                         ct = get_char_type(ch.char) if len(ch.char) == 1 else CharType.OTHER
                         is_linked = k > 0 and chars[idx + k - 1].linked_to_next
                         if ct == CharType.KANJI or is_linked:
                             ch.check_count = 0
+                        elif self._should_make_romaji_self_ruby(ch.char):
+                            ch.ruby = Ruby(parts=[RubyPart(text=ch.char)])
+                            ch.check_count = max(ch.check_count, 1)
                     # linked_to_next：同 block 内相邻字符 → True；否则 False。
                     # 词末字符（k == wlen-1）的 linked_to_next 不在 word 内部决定，
                     # 保守置 False（不连到 word 之外的下一字符）。
@@ -1761,6 +1850,7 @@ class AutoCheckService:
             return
         for sentence in project.sentences:
             self._apply_user_dictionary_to_sentence(sentence)
+            self._romanize_sentence_ruby(sentence)
 
     def update_checkpoints_from_rubies(
         self,
@@ -1829,7 +1919,7 @@ class AutoCheckService:
             ruby_groups = [p.text for p in char.ruby.parts]
             if len(ruby_groups) == 1 and char.char == ruby_groups[0]:
                 continue  # 自注音汉字（罕见），保留默认
-            if preserve_ruby_segments:
+            if preserve_ruby_segments or self._romanize_ruby:
                 # 保留原 ruby 分段：cc = parts 段数，这样后续 set_check_count
                 # 走 new_count == old_count 路径，不会触发 _resplit_ruby
                 # 重切 parts、丢失 offset_ms。
@@ -2064,6 +2154,15 @@ def get_kanji_linked_indices(characters: list) -> set:
 def _ruby_is_all_hiragana(ruby_text: str) -> bool:
     """注音文本是否全为平假名（范围 U+3040-U+309F）。"""
     return bool(ruby_text) and all("぀" <= c <= "ゟ" for c in ruby_text)
+
+
+def filter_delete_ruby_types_for_romaji(
+    type_names: List[str], romanize_ruby: bool
+) -> List[str]:
+    """过滤删除注音类型列表（模块级辅助，供 worker/home 等无 service 实例处调用）。"""
+    if not romanize_ruby:
+        return list(type_names)
+    return [n for n in type_names if n not in _ROMAJI_PROTECTED_DELETE_TYPES]
 
 
 def delete_rubies_by_type_names(

--- a/src/strange_uta_game/backend/infrastructure/parsers/romaji.py
+++ b/src/strange_uta_game/backend/infrastructure/parsers/romaji.py
@@ -1,0 +1,199 @@
+﻿"""假名→赫本式罗马音转换器（纯打表，零依赖）。"""
+
+from __future__ import annotations
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+_VOWELS = frozenset("aeiou")
+_PARTICLE_ROMAJI = {"\u306f": "wa", "\u3078": "e", "\u3092": "o"}
+
+_KANA: dict[str, str] = {
+    "あ": "a", "い": "i", "う": "u", "え": "e", "お": "o",
+    "か": "ka", "き": "ki", "く": "ku", "け": "ke", "こ": "ko",
+    "が": "ga", "ぎ": "gi", "ぐ": "gu", "げ": "ge", "ご": "go",
+    "さ": "sa", "し": "shi", "す": "su", "せ": "se", "そ": "so",
+    "ざ": "za", "じ": "ji", "ず": "zu", "ぜ": "ze", "ぞ": "zo",
+    "た": "ta", "ち": "chi", "つ": "tsu", "て": "te", "と": "to",
+    "だ": "da", "ぢ": "ji", "づ": "zu", "で": "de", "ど": "do",
+    "な": "na", "に": "ni", "ぬ": "nu", "ね": "ne", "の": "no",
+    "は": "ha", "ひ": "hi", "ふ": "fu", "へ": "he", "ほ": "ho",
+    "ば": "ba", "び": "bi", "ぶ": "bu", "べ": "be", "ぼ": "bo",
+    "ぱ": "pa", "ぴ": "pi", "ぷ": "pu", "ぺ": "pe", "ぽ": "po",
+    "ま": "ma", "み": "mi", "む": "mu", "め": "me", "も": "mo",
+    "や": "ya", "ゆ": "yu", "よ": "yo",
+    "ら": "ra", "り": "ri", "る": "ru", "れ": "re", "ろ": "ro",
+    "わ": "wa", "ゐ": "i", "ゑ": "e", "を": "o",
+    "ん": "n", "ゔ": "vu",
+    "ぁ": "a", "ぃ": "i", "ぅ": "u", "ぇ": "e", "ぉ": "o",
+    "ゃ": "ya", "ゅ": "yu", "ょ": "yo", "ゎ": "wa",
+}
+
+_DIGRAPHS: dict[str, str] = {
+    "きゃ": "kya", "きゅ": "kyu", "きょ": "kyo",
+    "ぎゃ": "gya", "ぎゅ": "gyu", "ぎょ": "gyo",
+    "しゃ": "sha", "しゅ": "shu", "しょ": "sho",
+    "じゃ": "ja", "じゅ": "ju", "じょ": "jo",
+    "ちゃ": "cha", "ちゅ": "chu", "ちょ": "cho",
+    "ぢゃ": "ja", "ぢゅ": "ju", "ぢょ": "jo",
+    "にゃ": "nya", "にゅ": "nyu", "にょ": "nyo",
+    "ひゃ": "hya", "ひゅ": "hyu", "ひょ": "hyo",
+    "びゃ": "bya", "びゅ": "byu", "びょ": "byo",
+    "ぴゃ": "pya", "ぴゅ": "pyu", "ぴょ": "pyo",
+    "みゃ": "mya", "みゅ": "myu", "みょ": "myo",
+    "りゃ": "rya", "りゅ": "ryu", "りょ": "ryo",
+    "うぃ": "wi", "うぇ": "we", "うぉ": "wo",
+    "ゔぁ": "va", "ゔぃ": "vi", "ゔぇ": "ve", "ゔぉ": "vo",
+    "ふぁ": "fa", "ふぃ": "fi", "ふぇ": "fe", "ふぉ": "fo",
+    "てぃ": "ti", "でぃ": "di", "とぅ": "tu", "どぅ": "du",
+    "しぇ": "she", "じぇ": "je", "ちぇ": "che",
+    "つぁ": "tsa", "つぃ": "tsi", "つぇ": "tse", "つぉ": "tso",
+    "くぁ": "kwa", "ぐぁ": "gwa",
+}
+
+_DIGRAPH_SPLIT: dict[str, Tuple[str, str]] = {
+    "kya": ("ky", "a"), "kyu": ("ky", "u"), "kyo": ("ky", "o"),
+    "gya": ("gy", "a"), "gyu": ("gy", "u"), "gyo": ("gy", "o"),
+    "sha": ("sh", "a"), "shu": ("sh", "u"), "sho": ("sh", "o"),
+    "ja": ("j", "a"), "ju": ("j", "u"), "jo": ("j", "o"),
+    "cha": ("ch", "a"), "chu": ("ch", "u"), "cho": ("ch", "o"),
+    "nya": ("ny", "a"), "nyu": ("ny", "u"), "nyo": ("ny", "o"),
+    "hya": ("hy", "a"), "hyu": ("hy", "u"), "hyo": ("hy", "o"),
+    "bya": ("by", "a"), "byu": ("by", "u"), "byo": ("by", "o"),
+    "pya": ("py", "a"), "pyu": ("py", "u"), "pyo": ("py", "o"),
+    "mya": ("my", "a"), "myu": ("my", "u"), "myo": ("my", "o"),
+    "rya": ("ry", "a"), "ryu": ("ry", "u"), "ryo": ("ry", "o"),
+}
+
+
+def _kata_to_hira_char(ch: str) -> str:
+    code = ord(ch)
+    if 0x30A1 <= code <= 0x30F6:
+        return chr(code - 0x60)
+    return ch
+
+
+def _last_vowel(text: str) -> str:
+    for ch in reversed(text.lower()):
+        if ch in _VOWELS:
+            return ch
+    return ""
+
+
+def _starts_with_vowel_or_y(text: str) -> bool:
+    if not text:
+        return False
+    lowered = text.lower()
+    return lowered[0] in _VOWELS or lowered.startswith("y")
+
+
+def _geminate_prefix(next_romaji: str) -> str:
+    lowered = next_romaji.lower()
+    if not lowered:
+        return ""
+    if lowered.startswith("ch"):
+        return "t"
+    first = lowered[0]
+    if first in _VOWELS or first == "n":
+        return ""
+    return first if first.isalpha() else ""
+
+
+def _split_digraph(romaji: str) -> Tuple[str, str]:
+    if romaji in _DIGRAPH_SPLIT:
+        return _DIGRAPH_SPLIT[romaji]
+    vowel = _last_vowel(romaji)
+    if vowel and romaji.endswith(vowel):
+        return romaji[:-1], vowel
+    return romaji, ""
+
+
+def _flat_chars(parts: Sequence[str]) -> List[Tuple[int, str]]:
+    return [(part_idx, ch) for part_idx, part in enumerate(parts) for ch in part]
+
+
+def _romaji_mora_at(flat: Sequence[Tuple[int, str]], index: int) -> str:
+    if index >= len(flat):
+        return ""
+    _, ch = flat[index]
+    hira = _kata_to_hira_char(ch)
+    if hira in ("っ", "ー"):
+        return ""
+    if hira == "ん":
+        return "n"
+    if index + 1 < len(flat):
+        _, next_ch = flat[index + 1]
+        pair = hira + _kata_to_hira_char(next_ch)
+        if pair in _DIGRAPHS:
+            return _DIGRAPHS[pair]
+    return _KANA.get(hira, ch)
+
+
+def romanize_ruby_parts(
+    parts: Iterable[str],
+    particle_indices: Optional[Iterable[int]] = None,
+) -> List[str]:
+    """将假名 RubyPart 文本逐一转为赫本式罗马音，保持 part 数量不变。"""
+    source = list(parts)
+    result = ["" for _ in source]
+    flat = _flat_chars(source)
+    particle_set = set(particle_indices or ())
+    prev_vowel = ""
+    index = 0
+
+    while index < len(flat):
+        part_idx, ch = flat[index]
+        hira = _kata_to_hira_char(ch)
+
+        if (
+            part_idx in particle_set
+            and len(source[part_idx]) == 1
+            and hira in _PARTICLE_ROMAJI
+        ):
+            romaji = _PARTICLE_ROMAJI[hira]
+            result[part_idx] += romaji
+            prev_vowel = _last_vowel(romaji)
+            index += 1
+            continue
+
+        if hira == "っ":
+            next_romaji = _romaji_mora_at(flat, index + 1)
+            prefix = _geminate_prefix(next_romaji)
+            result[part_idx] += prefix if prefix else "xtsu"
+            index += 1
+            continue
+
+        if hira == "ー":
+            repeated = prev_vowel or "-"
+            result[part_idx] += repeated
+            prev_vowel = repeated if repeated in _VOWELS else ""
+            index += 1
+            continue
+
+        if hira == "ん":
+            next_romaji = _romaji_mora_at(flat, index + 1)
+            romaji = "n'" if _starts_with_vowel_or_y(next_romaji) else "n"
+            result[part_idx] += romaji
+            prev_vowel = ""
+            index += 1
+            continue
+
+        if index + 1 < len(flat):
+            next_part_idx, next_ch = flat[index + 1]
+            pair = hira + _kata_to_hira_char(next_ch)
+            digraph = _DIGRAPHS.get(pair)
+            if digraph is not None:
+                if next_part_idx == part_idx:
+                    result[part_idx] += digraph
+                else:
+                    head, tail = _split_digraph(digraph)
+                    result[part_idx] += head
+                    result[next_part_idx] += tail
+                prev_vowel = _last_vowel(digraph)
+                index += 2
+                continue
+
+        romaji = _KANA.get(hira, ch)
+        result[part_idx] += romaji
+        prev_vowel = _last_vowel(romaji) or prev_vowel
+        index += 1
+
+    return result

--- a/src/strange_uta_game/config/config.json
+++ b/src/strange_uta_game/config/config.json
@@ -31,6 +31,7 @@
     "symbol": false,
     "space": false,
     "auto_on_load": true,
+    "romanize_ruby": false,
     "check_n": true,
     "check_sokuon": true,
     "check_long_vowel": false,

--- a/src/strange_uta_game/frontend/home/home_interface.py
+++ b/src/strange_uta_game/frontend/home/home_interface.py
@@ -500,11 +500,15 @@ class HomeInterface(QWidget):
                             auto_check.apply_to_project(project, only_noruby=True)
 
                     # 自动删除指定类型的注音
-                    delete_types = auto_check_flags.get("delete_ruby_types", [])
+                    from strange_uta_game.backend.application.auto_check_service import (
+                        delete_rubies_by_type_names,
+                        filter_delete_ruby_types_for_romaji,
+                    )
+                    delete_types = filter_delete_ruby_types_for_romaji(
+                        auto_check_flags.get("delete_ruby_types", []),
+                        auto_check_flags.get("romanize_ruby", False),
+                    )
                     if delete_types:
-                        from strange_uta_game.backend.application.auto_check_service import (
-                            delete_rubies_by_type_names,
-                        )
 
                         delete_rubies_by_type_names(project, delete_types)
             except Exception:

--- a/src/strange_uta_game/frontend/home/home_interface.py
+++ b/src/strange_uta_game/frontend/home/home_interface.py
@@ -500,15 +500,11 @@ class HomeInterface(QWidget):
                             auto_check.apply_to_project(project, only_noruby=True)
 
                     # 自动删除指定类型的注音
-                    from strange_uta_game.backend.application.auto_check_service import (
-                        delete_rubies_by_type_names,
-                        filter_delete_ruby_types_for_romaji,
-                    )
-                    delete_types = filter_delete_ruby_types_for_romaji(
-                        auto_check_flags.get("delete_ruby_types", []),
-                        auto_check_flags.get("romanize_ruby", False),
-                    )
+                    delete_types = auto_check_flags.get("delete_ruby_types", [])
                     if delete_types:
+                        from strange_uta_game.backend.application.auto_check_service import (
+                            delete_rubies_by_type_names,
+                        )
 
                         delete_rubies_by_type_names(project, delete_types)
             except Exception:

--- a/src/strange_uta_game/frontend/settings/app_settings.py
+++ b/src/strange_uta_game/frontend/settings/app_settings.py
@@ -68,7 +68,6 @@ class AppSettings:
             "check_english_word_end": True,
             "chinese_lyrics_detection": True,
             "romanize_ruby": False,
-            "delete_ruby_types_before_romanize": [],
             "delete_ruby_types": [],
         },
         "ui": {

--- a/src/strange_uta_game/frontend/settings/app_settings.py
+++ b/src/strange_uta_game/frontend/settings/app_settings.py
@@ -67,6 +67,8 @@ class AppSettings:
             "checkpoint_on_punctuation": False,
             "check_english_word_end": True,
             "chinese_lyrics_detection": True,
+            "romanize_ruby": False,
+            "delete_ruby_types_before_romanize": [],
             "delete_ruby_types": [],
         },
         "ui": {

--- a/src/strange_uta_game/frontend/settings/sub_interfaces/auto_check.py
+++ b/src/strange_uta_game/frontend/settings/sub_interfaces/auto_check.py
@@ -158,8 +158,7 @@ class AutoCheckSubInterface(SubSettingInterface):
                 s.set("auto_check.delete_ruby_types", saved_delete_types)
                 s.save()
             if romanize_ruby:
-                self._delete_types_before_romanize = list(
-                    s.get("auto_check.delete_ruby_types_before_romanize", saved_delete_types))
+                self._delete_types_before_romanize = list(saved_delete_types)
                 filtered = self._delete_types_without_romaji_exclusive(saved_delete_types)
                 if filtered != saved_delete_types:
                     saved_delete_types = filtered
@@ -189,5 +188,4 @@ class AutoCheckSubInterface(SubSettingInterface):
         else:
             self._delete_types_before_romanize = list(delete_types)
         s.set("auto_check.romanize_ruby", romanize_ruby)
-        s.set("auto_check.delete_ruby_types_before_romanize", self._delete_types_before_romanize)
         s.set("auto_check.delete_ruby_types", delete_types)

--- a/src/strange_uta_game/frontend/settings/sub_interfaces/auto_check.py
+++ b/src/strange_uta_game/frontend/settings/sub_interfaces/auto_check.py
@@ -9,8 +9,13 @@ from .base import SubSettingInterface
 
 
 class AutoCheckSubInterface(SubSettingInterface):
+    _ROMAJI_EXCLUSIVE_DELETE_TYPES = {"hiragana", "katakana_hiragana_ruby", "katakana_english_ruby", "kanji"}
+
     def __init__(self, parent=None):
         super().__init__(parent)
+        self._loading_values = False
+        self._delete_types_before_romanize: list[str] = []
+        self._skip_restore_on_romanize_off = False
         self._init_ui()
 
     def _init_ui(self):
@@ -43,6 +48,9 @@ class AutoCheckSubInterface(SubSettingInterface):
         self.card_chinese_lyrics_detection = SwitchSettingCard(FIF.LANGUAGE, "中文歌词检测",
             "加载歌词时，若未检测到日文假名则自动切换为中文模式（汉字每字一个节奏点，跳过日文注音）",
             parent=g)
+        self.card_romanize_ruby = SwitchSettingCard(FIF.LANGUAGE, "罗马音注音",
+            "需重新执行自动注音以生效",
+            parent=g)
         self.card_delete_ruby_types = MultiCheckSettingCard(
             FIF.DELETE, "自动删除注音", "自动注音完成后，自动删除指定类型的注音",
             options=[
@@ -56,7 +64,7 @@ class AutoCheckSubInterface(SubSettingInterface):
             ], parent=g)
         for c in [self.card_checkpoint_chars, self.card_check_rules,
                   self.card_auto_on_load, self.card_chinese_lyrics_detection,
-                  self.card_delete_ruby_types]:
+                  self.card_romanize_ruby, self.card_delete_ruby_types]:
             g.addSettingCard(c)
         self.expandLayout.addWidget(g)
 
@@ -65,48 +73,104 @@ class AutoCheckSubInterface(SubSettingInterface):
         self.card_check_rules.selection_changed.connect(self._notify_changed)
         self.card_auto_on_load.checked_changed.connect(self._notify_changed)
         self.card_chinese_lyrics_detection.checked_changed.connect(self._notify_changed)
-        self.card_delete_ruby_types.selection_changed.connect(self._notify_changed)
+        self.card_romanize_ruby.checked_changed.connect(self._on_romanize_ruby_changed)
+        self.card_delete_ruby_types.selection_changed.connect(self._on_delete_ruby_types_changed)
+
+    def _delete_types_without_romaji_exclusive(self, values: list[str]) -> list[str]:
+        return [v for v in values if v not in self._ROMAJI_EXCLUSIVE_DELETE_TYPES]
+
+    def _restore_delete_types_after_romaji(self, current: list[str]) -> list[str]:
+        restored = list(current)
+        for value in self._delete_types_before_romanize:
+            if value in self._ROMAJI_EXCLUSIVE_DELETE_TYPES and value not in restored:
+                restored.append(value)
+        return restored
+
+    def _on_romanize_ruby_changed(self, checked: bool):
+        if self._loading_values:
+            return
+        if checked:
+            selected = self.card_delete_ruby_types.selectedValues()
+            self._delete_types_before_romanize = list(selected)
+            filtered = self._delete_types_without_romaji_exclusive(selected)
+            if filtered != selected:
+                self.card_delete_ruby_types.setSelectedValues(filtered)
+        elif self._skip_restore_on_romanize_off:
+            self._skip_restore_on_romanize_off = False
+            self._delete_types_before_romanize = list(self.card_delete_ruby_types.selectedValues())
+        else:
+            selected = self.card_delete_ruby_types.selectedValues()
+            restored = self._restore_delete_types_after_romaji(selected)
+            if restored != selected:
+                self.card_delete_ruby_types.setSelectedValues(restored)
+        self._notify_changed()
+
+    def _on_delete_ruby_types_changed(self, selected: list[str]):
+        if self._loading_values:
+            return
+        if (self.card_romanize_ruby.isChecked()
+                and any(v in self._ROMAJI_EXCLUSIVE_DELETE_TYPES for v in selected)):
+            self._skip_restore_on_romanize_off = True
+            self.card_romanize_ruby.setChecked(False)
+        if not self.card_romanize_ruby.isChecked():
+            self._delete_types_before_romanize = list(self.card_delete_ruby_types.selectedValues())
+        self._notify_changed()
 
     def load_settings(self, s):
-        self.card_checkpoint_chars.setValues({
-            "hiragana": s.get("auto_check.hiragana", True),
-            "katakana": s.get("auto_check.katakana", True),
-            "kanji": s.get("auto_check.kanji", True),
-            "alphabet": s.get("auto_check.alphabet", False),
-            "digit": s.get("auto_check.digit", False),
-            "symbol": s.get("auto_check.symbol", False),
-            "space": s.get("auto_check.space", False),
-            "space_after_japanese": s.get("auto_check.space_after_japanese", True),
-            "space_after_alphabet": s.get("auto_check.space_after_alphabet", True),
-            "space_after_symbol": s.get("auto_check.space_after_symbol", True),
-        })
-        self.card_check_rules.setValues({
-            "check_n": s.get("auto_check.check_n", True),
-            "check_sokuon": s.get("auto_check.check_sokuon", True),
-            "check_long_vowel": s.get("auto_check.check_long_vowel", False),
-            "small_kana": s.get("auto_check.small_kana", False),
-            "check_parentheses": s.get("auto_check.check_parentheses", True),
-            "checkpoint_on_punctuation": s.get("auto_check.checkpoint_on_punctuation", False),
-            "check_empty_lines": s.get("auto_check.check_empty_lines", False),
-            "check_line_start": s.get("auto_check.check_line_start", False),
-            "check_line_end": s.get("auto_check.check_line_end", True),
-            "check_space_as_line_end": s.get("auto_check.check_space_as_line_end", True),
-            "check_english_word_end": s.get("auto_check.check_english_word_end", True),
-            "english_syllable_check": s.get("auto_check.english_syllable_check", True),
-        })
-        self.card_auto_on_load.setChecked(s.get("auto_check.auto_on_load", True))
-        self.card_chinese_lyrics_detection.setChecked(s.get("auto_check.chinese_lyrics_detection", True))
-        saved_delete_types = s.get("auto_check.delete_ruby_types", [])
-        # 向后兼容：将旧的 "katakana" 转换为新的两个子类型并自动更新配置
-        if "katakana" in saved_delete_types:
-            saved_delete_types.remove("katakana")
-            if "katakana_hiragana_ruby" not in saved_delete_types:
-                saved_delete_types.append("katakana_hiragana_ruby")
-            if "katakana_english_ruby" not in saved_delete_types:
-                saved_delete_types.append("katakana_english_ruby")
-            s.set("auto_check.delete_ruby_types", saved_delete_types)
-            s.save()
-        self.card_delete_ruby_types.setSelectedValues(saved_delete_types)
+        self._loading_values = True
+        try:
+            self.card_checkpoint_chars.setValues({
+                "hiragana": s.get("auto_check.hiragana", True),
+                "katakana": s.get("auto_check.katakana", True),
+                "kanji": s.get("auto_check.kanji", True),
+                "alphabet": s.get("auto_check.alphabet", False),
+                "digit": s.get("auto_check.digit", False),
+                "symbol": s.get("auto_check.symbol", False),
+                "space": s.get("auto_check.space", False),
+                "space_after_japanese": s.get("auto_check.space_after_japanese", True),
+                "space_after_alphabet": s.get("auto_check.space_after_alphabet", True),
+                "space_after_symbol": s.get("auto_check.space_after_symbol", True),
+            })
+            self.card_check_rules.setValues({
+                "check_n": s.get("auto_check.check_n", True),
+                "check_sokuon": s.get("auto_check.check_sokuon", True),
+                "check_long_vowel": s.get("auto_check.check_long_vowel", False),
+                "small_kana": s.get("auto_check.small_kana", False),
+                "check_parentheses": s.get("auto_check.check_parentheses", True),
+                "checkpoint_on_punctuation": s.get("auto_check.checkpoint_on_punctuation", False),
+                "check_empty_lines": s.get("auto_check.check_empty_lines", False),
+                "check_line_start": s.get("auto_check.check_line_start", False),
+                "check_line_end": s.get("auto_check.check_line_end", True),
+                "check_space_as_line_end": s.get("auto_check.check_space_as_line_end", True),
+                "check_english_word_end": s.get("auto_check.check_english_word_end", True),
+                "english_syllable_check": s.get("auto_check.english_syllable_check", True),
+            })
+            self.card_auto_on_load.setChecked(s.get("auto_check.auto_on_load", True))
+            self.card_chinese_lyrics_detection.setChecked(s.get("auto_check.chinese_lyrics_detection", True))
+            romanize_ruby = s.get("auto_check.romanize_ruby", False)
+            saved_delete_types = s.get("auto_check.delete_ruby_types", [])
+            if "katakana" in saved_delete_types:
+                saved_delete_types.remove("katakana")
+                if "katakana_hiragana_ruby" not in saved_delete_types:
+                    saved_delete_types.append("katakana_hiragana_ruby")
+                if "katakana_english_ruby" not in saved_delete_types:
+                    saved_delete_types.append("katakana_english_ruby")
+                s.set("auto_check.delete_ruby_types", saved_delete_types)
+                s.save()
+            if romanize_ruby:
+                self._delete_types_before_romanize = list(
+                    s.get("auto_check.delete_ruby_types_before_romanize", saved_delete_types))
+                filtered = self._delete_types_without_romaji_exclusive(saved_delete_types)
+                if filtered != saved_delete_types:
+                    saved_delete_types = filtered
+                    s.set("auto_check.delete_ruby_types", saved_delete_types)
+                    s.save()
+            else:
+                self._delete_types_before_romanize = list(saved_delete_types)
+            self.card_romanize_ruby.setChecked(romanize_ruby)
+            self.card_delete_ruby_types.setSelectedValues(saved_delete_types)
+        finally:
+            self._loading_values = False
 
     def collect_settings(self, s):
         for key, val in self.card_checkpoint_chars.values().items():
@@ -115,4 +179,15 @@ class AutoCheckSubInterface(SubSettingInterface):
             s.set(f"auto_check.{key}", val)
         s.set("auto_check.auto_on_load", self.card_auto_on_load.isChecked())
         s.set("auto_check.chinese_lyrics_detection", self.card_chinese_lyrics_detection.isChecked())
-        s.set("auto_check.delete_ruby_types", self.card_delete_ruby_types.selectedValues())
+        delete_types = self.card_delete_ruby_types.selectedValues()
+        romanize_ruby = self.card_romanize_ruby.isChecked()
+        if romanize_ruby:
+            filtered = self._delete_types_without_romaji_exclusive(delete_types)
+            if filtered != delete_types:
+                delete_types = filtered
+                self.card_delete_ruby_types.setSelectedValues(delete_types)
+        else:
+            self._delete_types_before_romanize = list(delete_types)
+        s.set("auto_check.romanize_ruby", romanize_ruby)
+        s.set("auto_check.delete_ruby_types_before_romanize", self._delete_types_before_romanize)
+        s.set("auto_check.delete_ruby_types", delete_types)

--- a/src/strange_uta_game/frontend/workers.py
+++ b/src/strange_uta_game/frontend/workers.py
@@ -198,21 +198,23 @@ class RubyAnalyzeWorker(QObject):
             def _progress_cb(current: int, total: int) -> None:
                 self.progress.emit(current, total)
 
+            delete_types = self._auto_check.filter_delete_ruby_types(self._delete_types)
+
             self._auto_check.apply_to_project(
                 self._project,
                 only_noruby=self._only_noruby,
-                apply_user_dict=not bool(self._delete_types),
+                apply_user_dict=not bool(delete_types),
                 progress_callback=_progress_cb,
             )
             self._auto_check.update_checkpoints_for_project(self._project)
 
             deleted_count = 0
-            if self._delete_types:
+            if delete_types:
                 from strange_uta_game.backend.application.auto_check_service import (
                     delete_rubies_by_type_names,
                 )
                 deleted_count = delete_rubies_by_type_names(
-                    self._project, self._delete_types
+                    self._project, delete_types
                 )
                 self._auto_check.apply_user_dict_to_project(self._project)
 

--- a/src/strange_uta_game/frontend/workers.py
+++ b/src/strange_uta_game/frontend/workers.py
@@ -198,25 +198,29 @@ class RubyAnalyzeWorker(QObject):
             def _progress_cb(current: int, total: int) -> None:
                 self.progress.emit(current, total)
 
-            delete_types = self._auto_check.filter_delete_ruby_types(self._delete_types)
-
+            # Step 1: 生成假名注音（延迟 romaji，delete 之后再转）
             self._auto_check.apply_to_project(
                 self._project,
                 only_noruby=self._only_noruby,
-                apply_user_dict=not bool(delete_types),
+                apply_user_dict=not bool(self._delete_types),
                 progress_callback=_progress_cb,
+                skip_romanize=True,
             )
             self._auto_check.update_checkpoints_for_project(self._project)
 
+            # Step 2: 按类型删除注音
             deleted_count = 0
-            if delete_types:
+            if self._delete_types:
                 from strange_uta_game.backend.application.auto_check_service import (
                     delete_rubies_by_type_names,
                 )
                 deleted_count = delete_rubies_by_type_names(
-                    self._project, delete_types
+                    self._project, self._delete_types
                 )
-                self._auto_check.apply_user_dict_to_project(self._project)
+                self._auto_check.apply_user_dict_to_project(self._project, skip_romanize=True)
+
+            # Step 3: 罗马音转换（走在 delete 之后，只转换剩余的假名注音）
+            self._auto_check.romanize_project_rubies(self._project)
 
             self.finished.emit(self._project, deleted_count)
         except Exception as e:

--- a/tests/unit/application/test_auto_check_romaji.py
+++ b/tests/unit/application/test_auto_check_romaji.py
@@ -1,0 +1,123 @@
+"""罗马音注音集成测试：验证 AutoCheckService 开关全链路行为。"""
+
+import pytest
+from strange_uta_game.backend.application import AutoCheckService
+from strange_uta_game.backend.domain import Character, Project, Ruby, RubyPart, Sentence
+from strange_uta_game.backend.infrastructure.parsers.ruby_analyzer import DummyAnalyzer, RubyAnalyzer, RubyResult
+
+ROMAJI_FLAGS = {"romanize_ruby": True, "check_n": True, "check_sokuon": True}
+
+
+class StaticAnalyzer(RubyAnalyzer):
+    def __init__(self, results):
+        self._results = results
+    def analyze(self, text: str):
+        return self._results
+    def get_reading(self, text: str) -> str:
+        return "".join(result.reading for result in self._results)
+
+
+def _ruby_parts(sentence: Sentence):
+    return [[part.text for part in ch.ruby.parts] if ch.ruby else [] for ch in sentence.characters]
+
+
+def test_kana_self_reading_gets_ruby_and_romaji():
+    service = AutoCheckService(DummyAnalyzer(), auto_check_flags=ROMAJI_FLAGS)
+    sentence = Sentence.from_text("あい", "s1")
+    service.apply_to_sentence(sentence)
+    assert _ruby_parts(sentence) == [["a"], ["i"]]
+    assert [ch.check_count for ch in sentence.characters] == [1, 1]
+
+
+def test_kanji_gets_romaji_ruby():
+    analyzer = StaticAnalyzer([RubyResult(text="今日", reading="きょう", start_idx=0, end_idx=2)])
+    service = AutoCheckService(analyzer, auto_check_flags=ROMAJI_FLAGS)
+    sentence = Sentence.from_text("今日", "s1")
+    service.apply_to_sentence(sentence)
+    parts = _ruby_parts(sentence)
+    for p_list in parts:
+        for p in p_list:
+            assert all(c.isascii() or c == "'" for c in p), f"Expected ASCII, got {p}"
+
+
+def test_sokuon_cross_part_context():
+    analyzer = StaticAnalyzer([
+        RubyResult(text="待", reading="ま", start_idx=0, end_idx=1),
+        RubyResult(text="っ", reading="っ", start_idx=1, end_idx=2),
+        RubyResult(text="て", reading="て", start_idx=2, end_idx=3),
+    ])
+    service = AutoCheckService(analyzer, auto_check_flags=ROMAJI_FLAGS)
+    sentence = Sentence.from_text("待って", "s1")
+    service.apply_to_sentence(sentence)
+    assert _ruby_parts(sentence) == [["ma"], ["t"], ["te"]]
+    assert [ch.check_count for ch in sentence.characters] == [1, 1, 1]
+
+
+def test_user_dict_romaji_override():
+    service = AutoCheckService(DummyAnalyzer(), auto_check_flags=ROMAJI_FLAGS,
+        user_dictionary=[{"enabled": True, "word": "今日", "reading": "{今日||きょ,う}"}])
+    sentence = Sentence.from_text("今日", "s1")
+    service.apply_to_sentence(sentence)
+    assert _ruby_parts(sentence) == [["kyo"], ["u"]]
+    assert [ch.check_count for ch in sentence.characters] == [1, 1]
+
+
+def test_user_dict_restores_kana_for_romaji():
+    service = AutoCheckService(DummyAnalyzer(), auto_check_flags=ROMAJI_FLAGS,
+        user_dictionary=[{"enabled": True, "word": "\u751f\u304d\u69d8",
+            "reading": "{\u751f||\u3044}\u304d{\u69d8||\u3056|\u307e}"}])
+    sentence = Sentence.from_text("\u751f\u304d\u69d8", "s1")
+    service.apply_to_sentence(sentence)
+    assert _ruby_parts(sentence) == [["i"], ["ki"], ["za", "ma"]]
+    assert [ch.check_count for ch in sentence.characters] == [1, 1, 2]
+
+
+def test_linked_kanji_no_romaji_self_ruby():
+    entries = [{"enabled": True, "word": "\u8cb4\u65b9", "reading": "{\u8cb4\u65b9||\u3042|\u306a|\u305f,}"}]
+    service = AutoCheckService(DummyAnalyzer(), auto_check_flags=ROMAJI_FLAGS, user_dictionary=entries)
+    sentence = Sentence.from_text("\u8cb4\u65b9", "s1")
+    service.apply_to_sentence(sentence)
+    chars = sentence.characters
+    assert chars[0].linked_to_next is True
+    assert chars[1].ruby is None
+    assert chars[1].check_count == 0
+
+
+def test_update_checkpoints_preserves_part_count_in_romaji_mode():
+    service = AutoCheckService(DummyAnalyzer(), auto_check_flags=ROMAJI_FLAGS)
+    sentence = Sentence(singer_id="s1", characters=[
+        Character(char="\u97f3", ruby=Ruby(parts=[RubyPart(text="hi"), RubyPart(text="bi"), RubyPart(text="ki")]),
+                  check_count=1, singer_id="s1")])
+    service.update_checkpoints_from_rubies(sentence)
+    assert sentence.characters[0].check_count == 3
+
+
+def test_default_off_preserves_kana_ruby():
+    service = AutoCheckService(DummyAnalyzer(), auto_check_flags={})
+    sentence = Sentence.from_text("あい", "s1")
+    service.apply_to_sentence(sentence)
+    assert _ruby_parts(sentence) == [[], []]
+    assert [ch.check_count for ch in sentence.characters] == [1, 1]
+
+
+def test_particle_wa_detection():
+    service = AutoCheckService(DummyAnalyzer(), auto_check_flags=ROMAJI_FLAGS)
+    sentence = Sentence.from_text("\u79c1\u306f", "s1")
+    service.apply_to_sentence(sentence)
+    parts = _ruby_parts(sentence)
+    assert parts[1] == ["wa"]
+
+
+def test_word_initial_ha_not_particle():
+    service = AutoCheckService(DummyAnalyzer(), auto_check_flags=ROMAJI_FLAGS)
+    sentence = Sentence.from_text("\u306f\u3058\u3081", "s1")
+    service.apply_to_sentence(sentence)
+    parts = _ruby_parts(sentence)
+    assert parts[0] == ["ha"]
+
+
+def test_wo_always_particle():
+    service = AutoCheckService(DummyAnalyzer(), auto_check_flags=ROMAJI_FLAGS)
+    sentence = Sentence.from_text("\u3092", "s1")
+    service.apply_to_sentence(sentence)
+    assert _ruby_parts(sentence) == [["o"]]

--- a/tests/unit/infrastructure/test_romaji.py
+++ b/tests/unit/infrastructure/test_romaji.py
@@ -1,0 +1,92 @@
+"""纯转换器测试：不依赖 Sentence/Character，只测 romanize_ruby_parts。"""
+
+from strange_uta_game.backend.infrastructure.parsers.romaji import romanize_ruby_parts
+
+
+class TestBasicKana:
+    def test_hepburn_basic(self):
+        assert romanize_ruby_parts(["し", "ち", "つ", "ふ", "じ"]) == ["shi", "chi", "tsu", "fu", "ji"]
+
+    def test_seion(self):
+        assert romanize_ruby_parts(["あ", "か", "さ", "た", "な"]) == ["a", "ka", "sa", "ta", "na"]
+
+    def test_dakuon(self):
+        assert romanize_ruby_parts(["が", "ざ", "だ", "ば"]) == ["ga", "za", "da", "ba"]
+
+    def test_handakuon(self):
+        assert romanize_ruby_parts(["ぱ", "ぴ", "ぷ", "ぺ", "ぽ"]) == ["pa", "pi", "pu", "pe", "po"]
+
+    def test_youon_same_part(self):
+        assert romanize_ruby_parts(["きゃ", "きゅ", "きょ"]) == ["kya", "kyu", "kyo"]
+        assert romanize_ruby_parts(["しゃ", "しゅ", "しょ"]) == ["sha", "shu", "sho"]
+        assert romanize_ruby_parts(["ちゃ", "ちゅ", "ちょ"]) == ["cha", "chu", "cho"]
+
+
+class TestSokuon:
+    def test_sokuon_gemination(self):
+        assert romanize_ruby_parts(["ま", "っ", "て"]) == ["ma", "t", "te"]
+
+    def test_sokuon_before_cha(self):
+        assert romanize_ruby_parts(["こ", "っ", "ち"]) == ["ko", "t", "chi"]
+
+    def test_sokuon_isolated(self):
+        assert romanize_ruby_parts(["っ"]) == ["xtsu"]
+
+
+class TestLongVowel:
+    def test_long_vowel_repeats_previous(self):
+        assert romanize_ruby_parts(["す", "ー", "ぱ", "ー"]) == ["su", "u", "pa", "a"]
+
+    def test_long_vowel_initial(self):
+        assert romanize_ruby_parts(["ー", "あ"]) == ["-", "a"]
+
+
+class TestN:
+    def test_n_before_vowel(self):
+        assert romanize_ruby_parts(["ん", "あ"]) == ["n'", "a"]
+
+    def test_n_before_consonant(self):
+        assert romanize_ruby_parts(["あ", "ん", "し"]) == ["a", "n", "shi"]
+
+    def test_n_before_y(self):
+        assert romanize_ruby_parts(["こ", "ん", "や"]) == ["ko", "n'", "ya"]
+
+
+class TestCrossPart:
+    def test_cross_part_youon_split(self):
+        assert romanize_ruby_parts(["き", "ょ", "う"]) == ["ky", "o", "u"]
+
+    def test_cross_part_youon_with_timing(self):
+        assert romanize_ruby_parts(["きょ", "う"]) == ["kyo", "u"]
+
+    def test_preserves_part_count_for_sokuon(self):
+        result = romanize_ruby_parts(["ま", "っ", "て"])
+        assert len(result) == 3
+
+
+class TestParticles:
+    def test_particle_opt_in(self):
+        assert romanize_ruby_parts(["は", "へ", "を"]) == ["ha", "he", "o"]
+
+    def test_particle_enabled(self):
+        assert romanize_ruby_parts(["は", "へ", "を"], particle_indices={0, 1, 2}) == ["wa", "e", "o"]
+
+    def test_only_wo_default_particle(self):
+        assert romanize_ruby_parts(["を"]) == ["o"]
+
+
+class TestEdgeCases:
+    def test_ascii_passthrough(self):
+        assert romanize_ruby_parts(["Ro", "me", "o"]) == ["Ro", "me", "o"]
+
+    def test_empty_input(self):
+        assert romanize_ruby_parts([]) == []
+
+    def test_katakana(self):
+        assert romanize_ruby_parts(["カ", "キ", "ク"]) == ["ka", "ki", "ku"]
+
+    def test_mixed_katakana_youon(self):
+        assert romanize_ruby_parts(["キャ", "キュ", "キョ"]) == ["kya", "kyu", "kyo"]
+
+    def test_katakana_sokuon(self):
+        assert romanize_ruby_parts(["マ", "ッ", "テ"]) == ["ma", "t", "te"]


### PR DESCRIPTION
Patch: 罗马音注音功能 (romaji ruby annotation)
基于: a8bfb9b (fix:自动滚动按钮大小异常)
日期: 2026-05-28

概述:
  在 AutoCheck 子选项中新增"罗马音注音"开关。开启后，自动注音生成的假名 RubyPart 文本将原地转换为赫本式 ASCII 罗马字（し→shi, つ→tsu 等），不改变 checkpoint 数量、连词结构、时间戳。

新增文件 (3):
  src/strange_uta_game/backend/infrastructure/parsers/romaji.py  — 转换器
  tests/unit/infrastructure/test_romaji.py                       — 转换器测试
  tests/unit/application/test_auto_check_romaji.py               — 集成测试

修改文件 (6):
  auto_check_service.py  — 接入罗马音转换 + 助词检测 + 删除类型过滤
  auto_check.py (UI)     — 开关卡片 + 与"删除注音"互斥联动
  config.json            — 新增 romanize_ruby 默认值
  app_settings.py        — 同上
  workers.py             — 使用过滤后的删除类型
  home_interface.py      — 同上

设计要点:
  - 纯打表转换
  - 整句上下文转换（促音っ需要看到后面的て）
  - 助词启发式检测（は→wa, へ→e, を→o）
  - 与"删除注音"互斥：开启罗马音后自动过滤平假名/片假名/汉字删除选项
  - 不变量保护：kanji/linked 字符不会错误生成 romaji self-ruby

测试: 35/35 passed