### PR TITLE
chore: add CODEOWNERS, AUTHORS, NOTICE, CHANGELOG; sync README to v3.0.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,35 @@
+# CODEOWNERS — auto-request review on PRs
+#
+# 不强制 review 通过才能 merge（branch protection 里 Required approvals = 0）
+# 这里只是告诉 GitHub PR 开了以后自动给谁发"请你瞄一眼"的通知。
+#
+# 顺序：最后一条匹配的规则生效。
+# 文档：https://docs.github.com/en/repositories/managing-your-repositories-settings-and-features/customizing-your-repository/about-code-owners
+
+# 默认 fallback：任一改动都通知双方
+*                                 @Myosotis11037 @Xuan-cc
+
+# 歌词打轴模块（原 StrangeUtaGame）—— Xuan-cc 主理
+/krok_helper/lyrics_timing/       @Xuan-cc
+
+# krok-helper 原有业务模块 —— Myosotis11037 主理
+/krok_helper/video_download/      @Myosotis11037
+/krok_helper/audio_alignment.py   @Myosotis11037
+/krok_helper/lyrics.py            @Myosotis11037
+/krok_helper/pipeline.py          @Myosotis11037
+/krok_helper/ffmpeg.py            @Myosotis11037
+/app.py                           @Myosotis11037
+/scripts/                         @Myosotis11037
+
+# 跨边界文件 —— 主窗口 / 设置 / 配置常量，改动通常涉及双方
+/krok_helper/gui_qt.py            @Myosotis11037 @Xuan-cc
+/krok_helper/settings.py          @Myosotis11037 @Xuan-cc
+/krok_helper/config.py            @Myosotis11037 @Xuan-cc
+
+# 仓库治理文件 —— 双方都要知道
+/.github/                         @Myosotis11037 @Xuan-cc
+/LICENSE                          @Myosotis11037 @Xuan-cc
+/NOTICE                           @Myosotis11037 @Xuan-cc
+/AUTHORS.md                       @Myosotis11037 @Xuan-cc
+/CHANGELOG.md                     @Myosotis11037 @Xuan-cc
+/README.md                        @Myosotis11037 @Xuan-cc

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,21 @@
+# AUTHORS
+
+本项目由以下作者共同维护。
+
+## Maintainers
+
+- **[Myosotis11037](https://github.com/Myosotis11037)**
+  - 原 [karaoke-helper](https://github.com/Myosotis11037/karaoke-helper) 作者
+  - 主理模块：视频下载（`krok_helper/video_download/`）、波形对齐（`krok_helper/audio_alignment.py`）、歌词检索（`krok_helper/lyrics.py`）、字幕渲染、Hi-Res 混流
+
+- **[Xuan-cc (Hoshiro)](https://github.com/Xuan-cc)**
+  - 原 [StrangeUtaGame](https://github.com/Xuan-cc/StrangeUtaGame) 作者
+  - 主理模块：歌词打轴（`krok_helper/lyrics_timing/`）
+
+## Acknowledgements
+
+歌词打轴模块的灵感与早期实现参考来自 [RhythmicaLyrics](http://suwa.pupu.jp/RhythmicaLyrics.html)（作者 すわ）。
+
+本项目使用 [un4seen developments](https://www.un4seen.com/bass.html) 的 BASS 音频库。BASS 对非商业用途免费；商业用途需另行购买授权（参见 `krok_helper/lyrics_timing/src/strange_uta_game/bass/` 下的 DLL 文件来自 BASS）。
+
+完整的合并与历史溯源说明见 [`NOTICE`](./NOTICE)。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+本项目所有重大变更都记录在此。
+
+格式参考 [Keep a Changelog](https://keepachangelog.com/zh-CN/)，
+版本号遵循 [Semantic Versioning](https://semver.org/lang/zh-CN/)。
+
+打轴模块（StrangeUtaGame）合并前的历史见
+[`krok_helper/lyrics_timing/CHANGELOG.md`](./krok_helper/lyrics_timing/CHANGELOG.md)。
+
+---
+
+## [Unreleased]
+
+### Changed
+
+- 仓库迁移至 `github.com/karaoke-studio/karaoke-studio`，由 Myosotis11037 与 Xuan-cc 共同维护
+- 合并 `Myosotis11037/karaoke-helper` 与 `Xuan-cc/StrangeUtaGame` 为单一仓库；StrangeUtaGame 源码重定位至 `krok_helper/lyrics_timing/`，git history 完整保留
+- 仓库整体采用 GPL-3.0 协议（合并前 krok-helper 无 LICENSE，StrangeUtaGame 为 GPL-3.0）
+
+### 下一步计划
+
+下一个发布版本 `v3.1.0` 将包含**打轴模块与主程序工作流的 UI 集成**（当前模块代码已合入，但主窗口第 4 步仍为占位）。
+
+---
+
+## [3.0.0] — 2026-06（合并前）
+
+`Myosotis11037/karaoke-helper` 作为独立项目发布的最后一个版本。
+
+详细变更见该版本 tag `v3.0.0` 的 commit 历史。
+
+StrangeUtaGame 同期版本为 `SUGv1.1.1`，相关历史见
+[`krok_helper/lyrics_timing/CHANGELOG.md`](./krok_helper/lyrics_timing/CHANGELOG.md)。

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,27 @@
+Karaoke Helper / 卡拉OK工作台
+==============================
+
+本项目由以下两个独立项目合并而成：
+
+  1. karaoke-helper
+     原仓库：https://github.com/Myosotis11037/karaoke-helper
+     Copyright (C) Myosotis11037
+
+  2. StrangeUtaGame
+     原仓库：https://github.com/Xuan-cc/StrangeUtaGame
+     Copyright (C) Xuan-cc (Hoshiro)
+
+合并发生于 2026 年 6 月，作为 git history 中
+`chore/merge-krok-helper` 合并到 `main` 的 merge commit
+（PR #57）记录在案。StrangeUtaGame 全部源码在该次合并中
+重定位到 `krok_helper/lyrics_timing/` 子目录，git rename
+检测保留 100% 相似度，blame 与 follow-rename 不丢。
+
+本合并作品整体采用 GNU General Public License v3.0
+（见 LICENSE 文件）。两个原项目在合并前均为 GPL-3.0。
+
+子目录 `krok_helper/lyrics_timing/` 下保留了 StrangeUtaGame
+原仓库的 CHANGELOG、README、LICENSE 等历史文件作为归档；
+仓库整体的协议以根目录 LICENSE 为准。
+
+作者列表与各模块的责任归属见 AUTHORS.md。

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Karaoke Helper（卡拉OK工作台）
 
-当前版本：`2.1.0`
+当前版本：`3.0.0`
 
 `Karaoke Helper` 是一个面向卡拉 OK / B 站投稿制作流程的 Windows 桌面工具。
 界面以一条「6 步工作流」串联整个制作链路，目前已经实现 4 个功能模块，另外 2 个为占位（规划中）。
@@ -14,7 +14,7 @@
 
 规划中（界面已占位，暂未实现）：
 
-- `歌词打轴`：逐句 / 逐字打轴
+- `歌词打轴`：逐句 / 逐字打轴 *（模块源码已合并自 [StrangeUtaGame](https://github.com/Xuan-cc/StrangeUtaGame)，位于 `krok_helper/lyrics_timing/`，UI 集成进行中）*
 - `字幕视频生成`：渲染字幕样式并输出字幕视频
 
 > 说明：本工具同时提供图形界面（默认）与命令行模式。命令行目前只覆盖 `Hi-Res 混流` 流程。
@@ -392,4 +392,12 @@ dist/macos/Karaoke Helper.app
 - Hi-Res 流程会先标准化输入音频，再封装进最终 `mkv`
 - B 站是否最终显示 `Hi-Res`，上传时仍需要你在投稿页手动勾选对应选项
 - 各在线接口（歌词来源、yt-dlp 解析、B 站登录）依赖第三方服务，可能随对方变动而失效
+
+## 协议与署名
+
+本项目以 [GNU General Public License v3.0](./LICENSE) 协议发布。
+
+由 [Myosotis11037](https://github.com/Myosotis11037) 与 [Xuan-cc (Hoshiro)](https://github.com/Xuan-cc) 共同维护，详见 [`AUTHORS.md`](./AUTHORS.md)。
+
+本仓库由 `karaoke-helper` 与 [`StrangeUtaGame`](https://github.com/Xuan-cc/StrangeUtaGame) 合并而成，合并细节见 [`NOTICE`](./NOTICE)，版本变更见 [`CHANGELOG.md`](./CHANGELOG.md)。
 </content>


### PR DESCRIPTION
仓库治理基础设施，作为 PR #57 合并之后的首个 governance PR。

- .github/CODEOWNERS: 按目录分配 review 通知归属（不强制 approval， Required reviews 保持 0；这里只是 PR 自动 request review 给对应 owner 让对方知道）
- AUTHORS.md: 双 maintainer + 模块责任 + BASS 鸣谢
- NOTICE: 合并历史 / 版权溯源 / 协议变更说明（合并自 Myosotis11037/karaoke-helper 与 Xuan-cc/StrangeUtaGame）
- CHANGELOG.md: 仓库级根 changelog，引用 krok_helper/lyrics_timing/CHANGELOG.md 作为 StrangeUtaGame 历史
- README.md: 当前版本号 2.1.0 -> 3.0.0；歌词打轴段落补一句 '模块源码已合并'；底部新增"协议与署名"段，指向 LICENSE / AUTHORS / NOTICE / CHANGELOG