### PR TITLE
feat(settings): SettingsProvider protocol + krok-helper lyrics_timing…

### DIFF
--- a/krok_helper/lyrics_timing/src/strange_uta_game/frontend/settings/app_settings.py
+++ b/krok_helper/lyrics_timing/src/strange_uta_game/frontend/settings/app_settings.py
@@ -3,14 +3,60 @@
 从 settings_interface.py 拆出，保留公共 API 不变：
 - ``AppSettings``：应用设置管理（config.json + dictionary.json + singers.json）
 - ``_parse_rl_dictionary``：RL 字典文本解析（模块内私有，被 AppSettings 和 DictionaryEditDialog 复用）
+
+PR #6B 增补：
+- ``SettingsProvider``：设置后端 Protocol，允许宿主（如 krok-helper）把
+  ``AppSettings`` 的持久化重定向到自己的存储。
+- ``AppSettings.__init__`` 增加可选 ``provider`` 参数；不传则保持完整
+  standalone 行为（文件读写 + dictionary 升级 + 独立 JSON 文件迁移）。
 """
 
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
 import json
 import sys
+
+
+@runtime_checkable
+class SettingsProvider(Protocol):
+    """设置持久化后端协议。
+
+    Standalone 模式下，AppSettings 内部使用一个文件型默认实现读写
+    ``config.json``。Embedded 模式下，宿主实现本协议把读写桥接到自己的
+    存储（如 krok-helper 的 ``%APPDATA%/Karaoke Helper/settings.json``
+    里的 ``lyrics_timing`` namespace）。
+
+    协议只覆盖**主 config**（即 ``config.json`` 等价物）的整字典读写；
+    词典/演唱者/网络词典三个独立文件不在本协议范围内 —— embedded 模式
+    下，这三类数据由宿主自己的 namespace 字段（``lyrics_timing_dictionary``
+    等）独立持久化，AppSettings 中对应的 ``load_dictionary`` /
+    ``load_singer_presets`` 等方法在 provider 模式下会返回空列表/字典。
+
+    实现示例（host bridge）::
+
+        class KrokHelperConfigProvider:
+            def __init__(self, app_settings, save_callback):
+                self._app_settings = app_settings
+                self._save_callback = save_callback
+
+            def load(self) -> dict:
+                return dict(self._app_settings.lyrics_timing)
+
+            def save(self, data: dict) -> None:
+                self._app_settings.lyrics_timing = dict(data)
+                self._save_callback()
+    """
+
+    def load(self) -> Dict[str, Any]:
+        """返回当前完整的设置字典；首次启动 / 空存储时返回 ``{}``。"""
+        ...
+
+    def save(self, data: Dict[str, Any]) -> None:
+        """把完整设置字典持久化到后端存储。"""
+        ...
 
 
 class AppSettings:
@@ -270,29 +316,69 @@ class AppSettings:
             return dev_path
         return None
 
-    def __init__(self, config_path: Optional[str] = None):
-        if config_path is None:
-            config_dir = self.get_config_dir()
-            try:
-                config_dir.mkdir(exist_ok=True)
-            except OSError:
-                # 程序目录不可写时回退到用户目录
-                config_dir = Path.home() / ".strange_uta_game"
-                config_dir.mkdir(exist_ok=True)
-            self._config_path = config_dir / "config.json"
-            # 如果用户配置不存在，从内嵌配置复制
-            if not self._config_path.exists():
-                self._copy_packaged_config()
-        else:
-            self._config_path = Path(config_path)
+    def __init__(
+        self,
+        config_path: Optional[str] = None,
+        *,
+        provider: Optional[SettingsProvider] = None,
+    ):
+        """初始化 AppSettings。
 
-        self._dict_path = self._config_path.parent / "dictionary.json"
-        self._network_dict_path = self._config_path.parent / "network_dictionary.json"
-        self._singers_path = self._config_path.parent / "singers.json"
-        self._settings = self._load_settings()
-        self._migrate_to_separate_files()
-        self._ensure_default_dictionary()
-        self._force_upgrade_dictionary_if_needed()
+        参数:
+            config_path: 显式 config.json 路径（standalone 调试用）。
+                仅在 ``provider`` 为 None 时生效。
+            provider: 设置后端 Protocol 实现。给定时**完全跳过**所有文件
+                路径初始化 —— 不解析 ``get_config_dir()``、不读写
+                ``config.json``、不做 dictionary 升级、不做独立文件
+                迁移。``self._settings`` 直接从 ``provider.load()`` 获取，
+                后续 ``save()`` 写回 provider。
+        """
+        self._provider = provider
+
+        if provider is None:
+            # ── standalone 模式：保持原有文件型行为 ──
+            if config_path is None:
+                config_dir = self.get_config_dir()
+                try:
+                    config_dir.mkdir(exist_ok=True)
+                except OSError:
+                    # 程序目录不可写时回退到用户目录
+                    config_dir = Path.home() / ".strange_uta_game"
+                    config_dir.mkdir(exist_ok=True)
+                self._config_path = config_dir / "config.json"
+                # 如果用户配置不存在，从内嵌配置复制
+                if not self._config_path.exists():
+                    self._copy_packaged_config()
+            else:
+                self._config_path = Path(config_path)
+
+            self._dict_path = self._config_path.parent / "dictionary.json"
+            self._network_dict_path = self._config_path.parent / "network_dictionary.json"
+            self._singers_path = self._config_path.parent / "singers.json"
+            self._settings = self._load_settings()
+            self._migrate_to_separate_files()
+            self._ensure_default_dictionary()
+            self._force_upgrade_dictionary_if_needed()
+        else:
+            # ── embedded 模式：通过 provider 桥接，不碰文件系统 ──
+            # 字段保留为 None 以保持类型一致；文件型方法（load_dictionary
+            # 等）在此模式下会因路径为 None 而返回空集合，由宿主单独
+            # 通过自己的 namespace 字段管理词典/演唱者/网络词典。
+            self._config_path = None  # type: ignore[assignment]
+            self._dict_path = None  # type: ignore[assignment]
+            self._network_dict_path = None  # type: ignore[assignment]
+            self._singers_path = None  # type: ignore[assignment]
+            # 先用内嵌默认值打底（保证 get() 取到合理默认），再用 provider
+            # 数据 deep-merge 覆盖。从 provider 接过来时 deepcopy，避免
+            # 后续 self.set 误改写到 provider 内部状态（一些朴素 provider
+            # 实现可能用浅拷贝传 dict 进来）。
+            self._settings = self._load_packaged_defaults()
+            try:
+                loaded = self._provider.load() or {}
+            except Exception:
+                loaded = {}
+            if isinstance(loaded, dict):
+                self._deep_merge(self._settings, deepcopy(loaded))
 
     def _force_upgrade_dictionary_if_needed(self) -> None:
         """词典版本升级：比较内置词典版本号与用户已应用版本号。
@@ -483,6 +569,19 @@ class AppSettings:
                 base[key] = value
 
     def save(self) -> None:
+        """持久化当前设置。
+
+        Provider 模式委托给 ``provider.save``；standalone 模式写
+        ``config.json``。两条路径都吞异常并打印日志，不抛。
+        """
+        if self._provider is not None:
+            try:
+                # deepcopy 出去：provider 应能持有完全独立的副本，避免
+                # 后续 AppSettings.set 改写到 provider 内部状态。
+                self._provider.save(deepcopy(self._settings))
+            except Exception as e:
+                print(f"保存设置失败 (provider): {e}")
+            return
         try:
             with open(self._config_path, "w", encoding="utf-8") as f:
                 json.dump(self._settings, f, indent=2, ensure_ascii=False)
@@ -490,7 +589,20 @@ class AppSettings:
             print(f"保存设置失败: {e}")
 
     def reload(self) -> None:
-        """从磁盘重新加载配置文件。"""
+        """从后端存储重新加载配置（discard 内存内未保存的改动）。
+
+        Provider 模式：以内嵌默认值打底，再 deep-merge provider.load() 结果。
+        Standalone 模式：走 ``_load_settings()`` 重读 config.json。
+        """
+        if self._provider is not None:
+            self._settings = self._load_packaged_defaults()
+            try:
+                loaded = self._provider.load() or {}
+            except Exception:
+                loaded = {}
+            if isinstance(loaded, dict):
+                self._deep_merge(self._settings, deepcopy(loaded))
+            return
         self._settings = self._load_settings()
 
     def get(self, path: str, default=None) -> Any:
@@ -566,11 +678,23 @@ class AppSettings:
             return default if default is not None else []
 
     def load_dictionary(self) -> list:
-        """从 dictionary.json 加载用户词典条目。"""
+        """从 dictionary.json 加载用户词典条目。
+
+        Provider 模式下文件路径为 None；本期 PR #6B 范围内 provider 不管
+        词典数据，直接返回空列表（宿主用自己的
+        ``lyrics_timing_dictionary`` namespace 独立持久化）。
+        """
+        if self._provider is not None:
+            return []
         return self._load_json(self._dict_path, [])
 
     def save_dictionary(self, entries: list) -> None:
-        """保存用户词典条目到 dictionary.json。"""
+        """保存用户词典条目到 dictionary.json。
+
+        Provider 模式下 noop —— 宿主自己管 ``lyrics_timing_dictionary``。
+        """
+        if self._provider is not None:
+            return
         self._save_json(self._dict_path, entries)
 
     def register_dictionary_word(self, word: str, reading: str) -> None:
@@ -641,7 +765,19 @@ class AppSettings:
         读取；cache（每源 entries / last_fetched）从 ``network_dictionary.json`` 读取。
         缺失任一文件用 :data:`DEFAULT_NETWORK_DICTIONARY_META` 兜底；自动补齐内置源。
         旧版（一体式 ``network_dictionary.json``）会被自动迁移：拆分后写回。
+
+        Provider 模式下不持久化网络词典；返回内嵌默认 meta + 空 cache，
+        实际数据由宿主的 ``lyrics_timing_network_dictionary`` namespace 管理。
         """
+        if self._provider is not None:
+            from strange_uta_game.backend.infrastructure.network_dictionary import (
+                DEFAULT_NETWORK_DICTIONARY_META,
+                ensure_builtin_sources,
+            )
+            meta = json.loads(json.dumps(DEFAULT_NETWORK_DICTIONARY_META))
+            ensure_builtin_sources(meta)
+            return {"meta": meta, "sources": {}}
+
         from strange_uta_game.backend.infrastructure.network_dictionary import (
             DEFAULT_NETWORK_DICTIONARY_META,
             ensure_builtin_sources,
@@ -680,13 +816,19 @@ class AppSettings:
         return ensure_builtin_sources(doc)
 
     def save_network_dictionary(self, doc: dict) -> None:
-        """保存统一文档：meta → ``config.json``，cache → ``network_dictionary.json``。"""
+        """保存统一文档：meta → ``config.json``，cache → ``network_dictionary.json``。
+
+        Provider 模式下 meta 仍走 self.set / self.save（由 provider 接管），
+        但 cache（独立文件）不落盘 —— 宿主负责。
+        """
         from strange_uta_game.backend.infrastructure.network_dictionary import (
             split_meta_and_cache,
         )
         meta, cache = split_meta_and_cache(doc)
         self.set("network_dictionary", meta)
         self.save()  # 立即落盘 meta 到 config.json
+        if self._provider is not None:
+            return
         self._save_json(self._network_dict_path, cache)
 
     def maybe_auto_update_network_dictionary(self, force: bool = False) -> "tuple[list, list, bool]":
@@ -695,6 +837,10 @@ class AppSettings:
         触发条件：``network_dictionary.auto_update.enabled=True`` 且距离
         ``last_auto_update_at`` 已超过 ``(interval_value, interval_unit)``。
         ``force=True`` 时无视条件强制执行（"立即同步"按钮可用）。
+
+        Provider 模式下短路返回（无 cache 文件可写、宿主自管网络词典
+        namespace）。MainWindow 在 embedded 模式下不会调度本方法（PR #6A
+        已跳过启动期定时器），这里再做一次防御。
 
         非阻塞建议：调用方在后台线程中调用本方法（HTTP 慢，UI 线程不可阻塞）。
 
@@ -705,6 +851,10 @@ class AppSettings:
             ``(ok_msgs, fail_msgs, ran)``：成功/失败消息列表 + 是否真的执行了拉取。
             未到期 / 未启用 / ``enabled=False`` → ``ran=False`` 且 msgs 为空。
         """
+        if self._provider is not None:
+            # Embedded mode: 宿主管网络词典 namespace，本方法 noop。
+            return ([], [], False)
+
         from strange_uta_game.backend.infrastructure.network_dictionary import (
             auto_update_enabled_sources,
             is_auto_update_due,
@@ -795,11 +945,18 @@ class AppSettings:
         )
 
     def load_singer_presets(self) -> list:
-        """从 singers.json 加载演唱者预设。"""
+        """从 singers.json 加载演唱者预设。
+
+        Provider 模式下空返回；宿主用 ``lyrics_timing_singers`` namespace 自管。
+        """
+        if self._provider is not None:
+            return []
         return self._load_json(self._singers_path, [])
 
     def save_singer_presets(self, presets: list) -> None:
-        """保存演唱者预设到 singers.json。"""
+        """保存演唱者预设到 singers.json。Provider 模式下 noop。"""
+        if self._provider is not None:
+            return
         self._save_json(self._singers_path, presets)
 
 

--- a/krok_helper/settings.py
+++ b/krok_helper/settings.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from krok_helper.config import APP_NAME
@@ -20,6 +21,10 @@ from krok_helper.video_download.download_task import NAMING_RULE_TITLE, SOURCE_Y
 SETTINGS_FILE_NAME = "settings.json"
 ALIGN_TARGET_VIDEO = "video"
 ALIGN_TARGET_AUDIO = "audio"
+
+# StrangeUtaGame 一次性迁移使用的 marker。
+# True 表示已经检测过老路径并完成（或确认无须）导入，不再重复。
+LYRICS_TIMING_MIGRATED_KEY = "lyrics_timing_migrated_v1"
 
 
 @dataclass
@@ -49,6 +54,18 @@ class AppSettings:
     video_download_retry_count: int = 3
     video_download_cookie_path: str = ""
     video_download_source: str = SOURCE_YOUTUBE
+
+    # ── 歌词打轴模块（StrangeUtaGame）的设置 namespace ──
+    # 由 frontend/settings/app_settings.py 中 AppSettings 的 dotted-key 树
+    # 序列化/反序列化得来，宿主直接以 dict 形式持久化；StrangeUtaGame
+    # 内部继续按它自己的 ``get("audio.default_volume")`` 风格读写。
+    # 大字典/列表型字段单独建独立 namespace，避免 lyrics_timing 主 dict 过大。
+    lyrics_timing: dict = field(default_factory=dict)
+    lyrics_timing_dictionary: dict = field(default_factory=dict)
+    lyrics_timing_singers: dict = field(default_factory=dict)
+    lyrics_timing_network_dictionary: dict = field(default_factory=dict)
+    # 一次性迁移 marker（见 :func:`migrate_strange_uta_game_settings`）
+    lyrics_timing_migrated_v1: bool = False
 
 
 def get_settings_path() -> Path:
@@ -122,6 +139,11 @@ def load_app_settings() -> AppSettings:
         video_download_retry_count=min(5, max(1, int(payload.get("video_download_retry_count", 3) or 3))),
         video_download_cookie_path=str(payload.get("video_download_cookie_path", "")),
         video_download_source=str(payload.get("video_download_source", SOURCE_YOUTUBE)),
+        lyrics_timing=_safe_dict(payload.get("lyrics_timing")),
+        lyrics_timing_dictionary=_safe_dict(payload.get("lyrics_timing_dictionary")),
+        lyrics_timing_singers=_safe_dict(payload.get("lyrics_timing_singers")),
+        lyrics_timing_network_dictionary=_safe_dict(payload.get("lyrics_timing_network_dictionary")),
+        lyrics_timing_migrated_v1=bool(payload.get(LYRICS_TIMING_MIGRATED_KEY, False)),
     )
 
 
@@ -133,3 +155,81 @@ def save_app_settings(settings: AppSettings) -> Path:
         encoding="utf-8",
     )
     return path
+
+
+def _safe_dict(value: object) -> dict:
+    """Return ``value`` if it's a dict, otherwise an empty dict.
+
+    Used by :func:`load_app_settings` when loading namespace fields that
+    must always end up as dicts even if the on-disk JSON contained a
+    non-dict value due to corruption or version skew.
+    """
+    return value if isinstance(value, dict) else {}
+
+
+# ════════════════════════════════════════════════════════════════════
+# StrangeUtaGame 一次性配置迁移
+# ════════════════════════════════════════════════════════════════════
+
+# StrangeUtaGame 在 standalone 模式下回退到这个目录写 config 当程序目录
+# 不可写时。见 ``frontend/settings/app_settings.py:get_config_dir``。
+_LEGACY_STRANGE_UTA_GAME_DIR = Path.home() / ".strange_uta_game"
+_LEGACY_FILES = {
+    "lyrics_timing": "config.json",
+    "lyrics_timing_dictionary": "dictionary.json",
+    "lyrics_timing_singers": "singers.json",
+    "lyrics_timing_network_dictionary": "network_dictionary.json",
+}
+
+
+def migrate_strange_uta_game_settings(
+    settings: AppSettings,
+    legacy_dir: Path | None = None,
+) -> bool:
+    """One-shot import of legacy StrangeUtaGame JSON files into ``settings``.
+
+    Scans ``legacy_dir`` (defaults to ``~/.strange_uta_game``) for the four
+    standalone JSON config files and merges their contents into the
+    matching namespace fields on the in-memory ``AppSettings``. If the
+    marker ``lyrics_timing_migrated_v1`` is already True, returns False
+    immediately so re-runs are no-ops.
+
+    The caller is responsible for persisting the result via
+    :func:`save_app_settings` — this function mutates ``settings`` in
+    place but does not touch disk on the krok-helper side. Reads from the
+    legacy files are best-effort: corrupt/missing files are skipped
+    silently.
+
+    Returns:
+        True if at least one legacy file was imported AND the marker
+        flipped to True. False if the marker was already set, the legacy
+        dir doesn't exist, or no files were importable.
+    """
+    if settings.lyrics_timing_migrated_v1:
+        return False
+
+    src = legacy_dir if legacy_dir is not None else _LEGACY_STRANGE_UTA_GAME_DIR
+    if not src.is_dir():
+        # 没有老安装可迁移 —— marker 直接置位避免每次启动都扫盘。
+        settings.lyrics_timing_migrated_v1 = True
+        return False
+
+    log = logging.getLogger(__name__)
+    imported_any = False
+    for namespace_field, filename in _LEGACY_FILES.items():
+        legacy_path = src / filename
+        if not legacy_path.is_file():
+            continue
+        try:
+            payload = json.loads(legacy_path.read_text(encoding="utf-8"))
+        except Exception:
+            log.warning("legacy StrangeUtaGame file unreadable: %s", legacy_path, exc_info=True)
+            continue
+        if not isinstance(payload, dict):
+            continue
+        # 直接覆盖整个 namespace；老用户首次启动我们以"老配置为准"。
+        setattr(settings, namespace_field, payload)
+        imported_any = True
+
+    settings.lyrics_timing_migrated_v1 = True
+    return imported_any


### PR DESCRIPTION
… namespace

PR #6B of the integration plan. Pure data-layer change: lays the foundation for host-injected settings persistence and reserves the namespace in krok-helper's settings.json for the lyrics_timing module. Does not touch MainWindow's signature (that comes in PR #6C).

## krok_helper/settings.py

Adds four new fields to `AppSettings` for the lyrics_timing module, plus a one-shot migration marker:

- `lyrics_timing: dict`            — equivalent of StrangeUtaGame's config.json
- `lyrics_timing_dictionary: dict` — equivalent of dictionary.json
- `lyrics_timing_singers: dict`    — equivalent of singers.json
- `lyrics_timing_network_dictionary: dict` — equivalent of network_dictionary.json
- `lyrics_timing_migrated_v1: bool` — migration sentinel

`load_app_settings` reads them safely (a `_safe_dict` helper falls back to `{}` on type mismatch), and `save_app_settings` picks them up automatically via `asdict()`.

`migrate_strange_uta_game_settings(settings, legacy_dir=None)` scans `~/.strange_uta_game/` (or a caller-supplied dir) for the four JSON files and merges them into the namespace fields. Idempotent — the sentinel flips to True on first run (whether or not anything was imported), so repeat calls are immediate no-ops. The caller is responsible for persisting the result via `save_app_settings`.

## krok_helper/lyrics_timing/.../frontend/settings/app_settings.py

Defines `SettingsProvider` Protocol (`@runtime_checkable`) with just two methods: `load() -> dict` and `save(data: dict)`. The whole settings tree round-trips through this interface — `get`/`set` continue to operate on an in-memory dict, so the Protocol does not need to expose dotted-path semantics.

`AppSettings.__init__` gains a keyword-only `provider` parameter. When provided:

- File-path attributes (`_config_path`, `_dict_path`, `_network_dict_path`, `_singers_path`) are set to None; no filesystem touched.
- The full standalone init chain (`_migrate_to_separate_files`, `_ensure_default_dictionary`, `_force_upgrade_dictionary_if_needed`, `_copy_packaged_config`) is skipped.
- `_settings` is seeded with packaged defaults, then deep-merged with whatever `provider.load()` returns.

`save()` and `reload()` route to the provider when set. The dictionary / singer / network methods (`load_dictionary`, `save_dictionary`, `load_singer_presets`, `save_singer_presets`, `load_network_dictionary`, `save_network_dictionary`, `maybe_auto_update_network_dictionary`) become safe no-ops / empty returns in provider mode — those four separate JSON files are out of scope for the base Protocol; the host manages them via the matching namespace fields on its own `AppSettings`.

All data crossing the provider boundary is `deepcopy`-ed (both directions). Otherwise a shallow-copying provider can end up sharing nested dicts with `_settings`, and a subsequent `set()` silently mutates the provider's internal state. (Caught while writing the unit-style smoke test.)

## Standalone behavior

Verified untouched:

- `python main.py` — MainWindow constructs cleanly (same smoke test as PR #6A).
- `AppSettings()` (no provider) — reads defaults from packaged config.json; e.g. `audio.default_volume == 80`.

## Smoke test results (provider mode)

- `AppSettings(provider=mp)` — `provider.load()` called once, `_config_path` is None, defaults still readable via `get()`.
- `set()` + `save()` — `provider.save()` called with full settings dict, downstream `provider._store` has the new values.
- `set()` followed by `reload()` — discards the in-memory change and re-reads from `provider.load()`.
- `load_dictionary()` / `load_singer_presets()` — return `[]`.
- `load_network_dictionary()` — returns dict with default meta and empty cache.
- `save_dictionary()` / `save_singer_presets()` — no-op, no exception.
- `isinstance(mp, SettingsProvider)` — True (runtime-checkable).

## Out of scope (deferred)

- Wiring `provider=` through `MainWindow.__init__` and `MainWindow.for_embedding(parent, settings_provider=None)` — PR #6C.
- The actual krok-helper bridge class implementing `SettingsProvider` against `AppSettings.lyrics_timing` — PR #6C.
- Host-side dictionary / singer / network namespace bridging — PR #6D or later. For PR #6C we'll embed with empty dict/singer/network and iterate on those if user demand is real.