### PR TITLE
fix: flush embedded timing page edges

### DIFF
--- a/krok_helper/gui_qt.py
+++ b/krok_helper/gui_qt.py
@@ -2272,7 +2272,7 @@ class KrokHelperQtApp(QMainWindow):
         central = QWidget()
         central.setObjectName("AppRoot")
         shell = QVBoxLayout(central)
-        shell.setContentsMargins(24, 20, 24, 16)
+        shell.setContentsMargins(0, 0, 0, 0)
         shell.setSpacing(12)
 
         self.workflow_stepper = WorkflowStepper(WORKFLOW_STEPS, self)
@@ -2286,8 +2286,22 @@ class KrokHelperQtApp(QMainWindow):
         workflow_bar_layout.setSpacing(10)
         workflow_bar_layout.addWidget(self.workflow_stepper, 1)
 
+        workflow_bar_container = QWidget()
+        workflow_bar_shell = QVBoxLayout(workflow_bar_container)
+        workflow_bar_shell.setContentsMargins(24, 20, 24, 0)
+        workflow_bar_shell.setSpacing(0)
+        workflow_bar_shell.addWidget(workflow_bar)
+
         self.page_stack = QStackedWidget()
         self.page_stack.setObjectName("PageStack")
+        page_stack_container = QWidget()
+        self._page_stack_container_layout = QVBoxLayout(page_stack_container)
+        self._page_stack_normal_margins = (24, 0, 24, 16)
+        self._page_stack_flush_margins = (0, 0, 0, 16)
+        self._page_stack_container_layout.setContentsMargins(*self._page_stack_normal_margins)
+        self._page_stack_container_layout.setSpacing(0)
+        self._page_stack_container_layout.addWidget(self.page_stack)
+
         self.video_download_page = VideoDownloadPage(self.settings, self._save_all_settings, self)
         self.align_page = self._build_alignment_page()
         self.lyrics_page = self._build_lyrics_page()
@@ -2320,8 +2334,8 @@ class KrokHelperQtApp(QMainWindow):
         self.page_stack.addWidget(self.subtitle_render_page)
         self.page_stack.addWidget(self.hires_page)
 
-        shell.addWidget(workflow_bar)
-        shell.addWidget(self.page_stack, 1)
+        shell.addWidget(workflow_bar_container)
+        shell.addWidget(page_stack_container, 1)
         self.setCentralWidget(central)
         self.statusBar().hide()
         self._show_module(WORKFLOW_VIDEO_DOWNLOAD)
@@ -2338,8 +2352,20 @@ class KrokHelperQtApp(QMainWindow):
         ):
             self._stop_alignment_preview()
         self.active_module = module_id
+        self._sync_page_stack_margins(module_id)
         self.page_stack.setCurrentWidget(self.module_pages[module_id])
         self.workflow_stepper.setCurrentModule(module_id)
+
+    def _sync_page_stack_margins(self, module_id: str) -> None:
+        layout = getattr(self, "_page_stack_container_layout", None)
+        if layout is None:
+            return
+        margins = (
+            self._page_stack_flush_margins
+            if module_id == WORKFLOW_LYRICS_TIMING
+            else self._page_stack_normal_margins
+        )
+        layout.setContentsMargins(*margins)
 
     def _handle_workflow_step_clicked(self, index: int) -> None:
         self._show_module(self.workflow_stepper.moduleIdAt(index))

--- a/krok_helper/lyrics_timing/src/strange_uta_game/frontend/editor/timing/file_loader.py
+++ b/krok_helper/lyrics_timing/src/strange_uta_game/frontend/editor/timing/file_loader.py
@@ -225,8 +225,7 @@ class FileLoader:
 
         # 应用设置中的默认音量和速度
         if self._timing_service:
-            main_window = self._editor.window()
-            setting_iface = getattr(main_window, "settingInterface", None)
+            setting_iface = self._editor._get_setting_interface()
             if setting_iface is not None:
                 settings = setting_iface.get_settings()
                 default_volume = int(settings.get("audio.default_volume", 80))

--- a/krok_helper/lyrics_timing/src/strange_uta_game/frontend/editor/timing/timeline_widget.py
+++ b/krok_helper/lyrics_timing/src/strange_uta_game/frontend/editor/timing/timeline_widget.py
@@ -60,6 +60,7 @@ class WaveformDisplay(QWidget):
 
         # 缩放和滚动
         self._zoom_factor: float = 50.0  # 默认50x缩放，减少初始渲染压力
+        self._zoom_enabled: bool = True
         self._scroll_position: float = 0.0
 
         # 波形峰值缓存
@@ -161,6 +162,9 @@ class WaveformDisplay(QWidget):
         # 缩放变化后重新 clamp，避免当前滚动位置超出新的有效范围
         self._scroll_position = self._clamp_scroll(self._scroll_position)
         self.update()
+
+    def set_zoom_enabled(self, enabled: bool) -> None:
+        self._zoom_enabled = enabled
 
     def set_scroll_position(self, position: float):
         self._scroll_position = self._clamp_scroll(position)
@@ -392,6 +396,9 @@ class WaveformDisplay(QWidget):
     def wheelEvent(self, a0: Optional[QWheelEvent]):
         if a0 is None:
             return
+        if not self._zoom_enabled:
+            a0.ignore()
+            return
 
         delta = a0.angleDelta().y()
         new_zoom = self._zoom_factor * (1.2 if delta > 0 else 1 / 1.2)
@@ -427,6 +434,7 @@ class TimelineWidget(QWidget):
         super().__init__(parent)
         self._duration_ms = 0
         self._waveform_visible = True
+        self._zoom_enabled = True
         self._init_ui()
 
     def _init_ui(self):
@@ -501,6 +509,12 @@ class TimelineWidget(QWidget):
     def set_playing(self, playing: bool) -> None:
         self.waveform_display.set_playing(playing)
 
+    def set_zoom_enabled(self, enabled: bool) -> None:
+        self._zoom_enabled = enabled
+        self.waveform_display.set_zoom_enabled(enabled)
+        self.zoom_slider.setEnabled(enabled)
+        self.zoom_label.setEnabled(enabled)
+
     # ---- 缩放对数刻度转换（zoom 范围 1x-100x，slider 范围 0-10000）----
 
     @staticmethod
@@ -528,6 +542,8 @@ class TimelineWidget(QWidget):
         self.scroll_bar.blockSignals(False)
 
     def _on_zoom_slider_changed(self, value: int):
+        if not self._zoom_enabled:
+            return
         self.waveform_display._suspend_auto_scroll()
         zoom = self._slider_to_zoom(value)
         self.waveform_display.set_zoom(zoom)

--- a/krok_helper/lyrics_timing/src/strange_uta_game/frontend/editor/timing_interface.py
+++ b/krok_helper/lyrics_timing/src/strange_uta_game/frontend/editor/timing_interface.py
@@ -407,6 +407,17 @@ class EditorInterface(QWidget):
         self._store = store
         store.data_changed.connect(self._on_data_changed)
 
+    def _get_setting_interface(self):
+        """Return SUG's settings interface even when embedded in a host window."""
+        widget = self
+        while widget is not None:
+            setting_iface = getattr(widget, "settingInterface", None)
+            if setting_iface is not None:
+                return setting_iface
+            widget = widget.parentWidget()
+        main_window = self.window()
+        return getattr(main_window, "settingInterface", None)
+
     def _on_data_changed(self, change_type: str):
         """响应 ProjectStore 的数据变更。"""
         if change_type == "project":
@@ -425,9 +436,9 @@ class EditorInterface(QWidget):
         """从 AppSettings 读取设定并应用到编辑器。"""
         if not self._store:
             return
-        # 通过 MainWindow 的 settingInterface 获取 AppSettings
-        main_window = self.window()
-        setting_iface = getattr(main_window, "settingInterface", None)
+        # In embedded mode, self.window() is the host window. Walk parents to
+        # find SUG's own MainWindow so runtime settings apply immediately.
+        setting_iface = self._get_setting_interface()
         if setting_iface is None:
             return
         settings = setting_iface.get_settings()
@@ -717,8 +728,7 @@ class EditorInterface(QWidget):
         # 否则 _store.notify("settings") 触发 _apply_settings() 时读到的还是旧值，
         # 会立刻把刚设的偏移回滚掉。
         try:
-            main_window = self.window()
-            setting_iface = getattr(main_window, "settingInterface", None)
+            setting_iface = self._get_setting_interface()
             if setting_iface:
                 app_settings = setting_iface.get_settings()
             else:
@@ -747,8 +757,7 @@ class EditorInterface(QWidget):
         # 获取AppSettings实例（与_apply_settings使用同一个）
         app_settings = None
         try:
-            main_window = self.window()
-            setting_iface = getattr(main_window, "settingInterface", None)
+            setting_iface = self._get_setting_interface()
             if setting_iface:
                 app_settings = setting_iface.get_settings()
         except Exception:
@@ -2641,8 +2650,7 @@ class EditorInterface(QWidget):
 
         # 应用设置中的默认音量和速度
         if self._timing_service:
-            main_window = self.window()
-            setting_iface = getattr(main_window, "settingInterface", None)
+            setting_iface = self._get_setting_interface()
             if setting_iface is not None:
                 settings = setting_iface.get_settings()
                 default_volume = int(settings.get("audio.default_volume", 80))
@@ -4865,8 +4873,7 @@ class EditorInterface(QWidget):
         self._scroll_mode = modes[(modes.index(self._scroll_mode) + 1) % len(modes)]
         self._sync_scroll_mode()
         # 持久化到 config
-        main_window = self.window()
-        setting_iface = getattr(main_window, "settingInterface", None)
+        setting_iface = self._get_setting_interface()
         if setting_iface is not None:
             s = setting_iface.get_settings()
             s.set("timing.scroll_mode", self._scroll_mode)

--- a/krok_helper/lyrics_timing/src/strange_uta_game/frontend/main_window.py
+++ b/krok_helper/lyrics_timing/src/strange_uta_game/frontend/main_window.py
@@ -95,6 +95,7 @@ class MainWindow(MSFluentWindow):
         self._init_window()
         self._init_interfaces()
         self._init_navigation()
+        self._apply_embedded_ui_policy()
 
         # 中央响应：store 的 project 变更 → 同步 timing_service 等
         self._store.data_changed.connect(self._on_data_changed)
@@ -221,6 +222,14 @@ class MainWindow(MSFluentWindow):
             pass
         except Exception:
             pass
+
+    def _apply_embedded_ui_policy(self) -> None:
+        """Apply host-owned UI behavior that only exists in embedded mode."""
+        if not self._embedded:
+            return
+        timeline = getattr(getattr(self, "editorInterface", None), "timeline", None)
+        if timeline is not None and hasattr(timeline, "set_zoom_enabled"):
+            timeline.set_zoom_enabled(False)
 
     def _restore_window_geometry(self):
         """启动时从 config.json 恢复窗口大小与最大化状态（仅读取一次）。
@@ -1185,6 +1194,7 @@ class MainWindow(MSFluentWindow):
         instance = MainWindow(embedded=True, settings_provider=settings_provider)
         instance.setWindowFlags(Qt.WindowType.Widget)
         instance._remove_embedded_title_bar()
+        instance._apply_embedded_ui_policy()
         if parent is not None:
             instance.setParent(parent)  # type: ignore[arg-type]
         return instance


### PR DESCRIPTION
﻿## Summary

- let the embedded lyrics timing page stretch to the workbench left and right edges while preserving the padded layout for other workflow modules
- disable the embedded SUG timeline zoom slider and waveform wheel zoom
- keep standalone SUG timeline zoom enabled by default

## Validation

- embedded smoke: lyrics timing margins become 0/0, other modules restore 24/24, embedded timeline zoom is disabled
- standalone smoke: a standalone `TimelineWidget` still has zoom enabled
- `.venv\Scripts\python.exe -m py_compile krok_helper/gui_qt.py krok_helper/lyrics_timing/src/strange_uta_game/frontend/main_window.py krok_helper/lyrics_timing/src/strange_uta_game/frontend/editor/timing/timeline_widget.py`
- `.venv\Scripts\python.exe -m pytest tests/test_ffmpeg_paths.py tests/test_lyrics_timing_namespaces.py tests/video_download/test_settings_roundtrip.py tests/video_download/test_download_task_defaults.py`
- `.venv\Scripts\python.exe -m pytest tests/`

Co-Authored-By: Codex <noreply@openai.com>
