### PR TITLE
[codex] Add global settings and workbench updater

### DIFF
--- a/krok_helper/gui_qt.py
+++ b/krok_helper/gui_qt.py
@@ -31,6 +31,8 @@ from PyQt6.QtWidgets import (
     QHeaderView,
     QHBoxLayout,
     QLabel,
+    QListWidget,
+    QListWidgetItem,
     QMainWindow,
     QMessageBox,
     QScrollArea,
@@ -51,6 +53,7 @@ from qfluentwidgets import (
     FluentIcon as FIF,
     LineEdit as QLineEdit,
     PlainTextEdit as QPlainTextEdit,
+    Pivot,
     PrimaryPushButton,
     ProgressBar as QProgressBar,
     PushButton as QPushButton,
@@ -90,6 +93,7 @@ from krok_helper.audio_alignment import (
 from krok_helper.config import (
     APP_NAME,
     APP_TITLE,
+    APP_VERSION,
     WINDOW_HEIGHT,
     WINDOW_MIN_HEIGHT,
     WINDOW_MIN_WIDTH,
@@ -128,6 +132,9 @@ from krok_helper.settings import (
     migrate_strange_uta_game_settings,
     save_app_settings,
 )
+from krok_helper.updater import CheckResult, UpdateChecker, ensure_updater_settings
+from krok_helper.updater.settings import UpdaterSettings
+from krok_helper.updater.sources import SOURCE_IDS, SOURCE_LABELS, normalize_order
 from krok_helper.video_download import VideoDownloadPage
 from krok_helper.windows import set_explicit_app_user_model_id
 
@@ -1816,6 +1823,7 @@ class KrokHelperQtApp(QMainWindow):
         self.align_analysis_task: BackgroundTask | None = None
         self.align_auto_task: BackgroundTask | None = None
         self.align_export_task: BackgroundTask | None = None
+        self._update_checker: UpdateChecker | None = None
         self.lyrics_search_service = LyricsSearchService()
         self.lyrics_search_results: list[LyricsSearchCandidate] = []
         self.lyrics_pending_results: list[LyricsSearchCandidate] = []
@@ -1880,6 +1888,7 @@ class KrokHelperQtApp(QMainWindow):
         self.preview_timer = QTimer(self)
         self.preview_timer.setInterval(300)
         self.preview_timer.timeout.connect(self._poll_alignment_preview)
+        QTimer.singleShot(2500, self._check_for_workbench_update_on_startup)
 
     def _track_background_task(self, attr_name: str, task: BackgroundTask) -> BackgroundTask:
         task.setObjectName(attr_name)
@@ -2014,6 +2023,15 @@ class KrokHelperQtApp(QMainWindow):
                 border: 1px solid #E3E8F0;
                 border-radius: 8px;
             }
+            QFrame#WhitePanel {
+                background: #FFFFFF;
+                border: 1px solid #E1E7F0;
+                border-radius: 8px;
+            }
+            Pivot {
+                background: transparent;
+                border: 0;
+            }
             QWidget#LyricsPage {
                 background: #F4F7FB;
             }
@@ -2044,6 +2062,16 @@ class KrokHelperQtApp(QMainWindow):
             ToolButton#AlignMaterialSettingsButton:hover {
                 background: #F3F4F6;
                 border-color: #E5E7EB;
+            }
+            ToolButton#GlobalSettingsButton {
+                background: #FFFFFF;
+                border: 1px solid #D7DEE9;
+                border-radius: 8px;
+                padding: 4px;
+            }
+            ToolButton#GlobalSettingsButton:hover {
+                background: #FFF6F7;
+                border-color: #F3A8B3;
             }
             QLabel#PageTitle {
                 color: #1f2937;
@@ -2285,6 +2313,13 @@ class KrokHelperQtApp(QMainWindow):
         workflow_bar_layout.setContentsMargins(10, 8, 10, 8)
         workflow_bar_layout.setSpacing(10)
         workflow_bar_layout.addWidget(self.workflow_stepper, 1)
+        self.global_settings_button = ToolButton(FIF.SETTING)
+        self.global_settings_button.setObjectName("GlobalSettingsButton")
+        self.global_settings_button.setToolTip("全局设置")
+        self.global_settings_button.setFixedSize(48, 48)
+        self.global_settings_button.setIconSize(QSize(20, 20))
+        self.global_settings_button.clicked.connect(self._open_global_settings_window)
+        workflow_bar_layout.addWidget(self.global_settings_button, 0, Qt.AlignmentFlag.AlignVCenter)
 
         workflow_bar_container = QWidget()
         workflow_bar_shell = QVBoxLayout(workflow_bar_container)
@@ -3075,9 +3110,7 @@ class KrokHelperQtApp(QMainWindow):
         settings_button.clicked.connect(lambda: self._open_settings_window("hires"))
         settings_layout.addWidget(output_label, 0, 0)
         settings_layout.addWidget(self.output_dir_label, 0, 1)
-        settings_layout.addWidget(ffmpeg_title, 1, 0)
-        settings_layout.addWidget(self.hires_ffmpeg_label, 1, 1)
-        settings_layout.addWidget(settings_button, 1, 2)
+        settings_layout.addWidget(settings_button, 0, 2)
         settings_layout.setColumnStretch(1, 1)
         shell.addWidget(settings_card)
 
@@ -5129,34 +5162,6 @@ class KrokHelperQtApp(QMainWindow):
         heading.setStyleSheet('font-family: "Microsoft YaHei UI"; font-size: 18pt; font-weight: 700;')
         shell.addWidget(heading)
 
-        ffmpeg_panel = QFrame()
-        ffmpeg_panel.setObjectName("WhitePanel")
-        ffmpeg_layout = QGridLayout(ffmpeg_panel)
-        ffmpeg_layout.setContentsMargins(14, 14, 14, 14)
-        ffmpeg_title = QLabel("FFmpeg 目录")
-        ffmpeg_title.setObjectName("PanelTitle")
-        ffmpeg_display = QLineEdit(dialog)
-        ffmpeg_display.setText(self.ffmpeg_dir_text)
-        ffmpeg_display.setPlaceholderText(FFMPEG_DIR_PLACEHOLDER)
-        choose_button = QPushButton("选择目录")
-        choose_button.clicked.connect(
-            lambda: self._choose_ffmpeg_for_dialog(dialog, ffmpeg_display)
-        )
-        system_button = QPushButton("使用系统 PATH")
-        system_button.clicked.connect(lambda: ffmpeg_display.setText(""))
-        ffmpeg_hint_1 = QLabel("推荐直接选择 ffmpeg 的 bin 目录，例如 D:\\tools\\ffmpeg\\bin。")
-        ffmpeg_hint_1.setStyleSheet('font-family: "Microsoft YaHei UI"; font-size: 9pt; color: #6b7280;')
-        ffmpeg_hint_2 = QLabel("也可以选择 ffmpeg 根目录，程序会尝试其中的 bin\\ffmpeg.exe 和 bin\\ffprobe.exe。")
-        ffmpeg_hint_2.setStyleSheet('font-family: "Microsoft YaHei UI"; font-size: 9pt; color: #6b7280;')
-        ffmpeg_layout.addWidget(ffmpeg_title, 0, 0)
-        ffmpeg_layout.addWidget(ffmpeg_display, 0, 1)
-        ffmpeg_layout.addWidget(choose_button, 0, 2)
-        ffmpeg_layout.addWidget(system_button, 0, 3)
-        ffmpeg_layout.addWidget(ffmpeg_hint_1, 1, 1, 1, 3)
-        ffmpeg_layout.addWidget(ffmpeg_hint_2, 2, 1, 1, 3)
-        ffmpeg_layout.setColumnStretch(1, 1)
-        shell.addWidget(ffmpeg_panel)
-
         status_label = QLabel("")
         status_label.setStyleSheet('font-family: "Microsoft YaHei UI"; font-size: 9pt; color: #177245;')
 
@@ -5259,7 +5264,7 @@ class KrokHelperQtApp(QMainWindow):
                     off_template=off_template,
                     align_video_template=align_video_template,
                     align_audio_template=align_audio_template,
-                    ffmpeg_dir_text=ffmpeg_display.text().strip(),
+                    ffmpeg_dir_text=self.ffmpeg_dir_text,
                 )
             except ProcessingError as exc:
                 QMessageBox.critical(dialog, APP_TITLE, str(exc))
@@ -5278,6 +5283,510 @@ class KrokHelperQtApp(QMainWindow):
         path = QFileDialog.getExistingDirectory(parent, "选择 ffmpeg 所在目录")
         if path:
             target.setText(path)
+
+    def _open_global_settings_window(self) -> None:
+        updater_settings = ensure_updater_settings(self.settings)
+        dialog = QDialog(self)
+        dialog.setWindowTitle(f"{APP_TITLE} - 全局设置")
+        dialog.resize(780, 520)
+
+        outer = QVBoxLayout(dialog)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.setSpacing(0)
+
+        scroll = QScrollArea(dialog)
+        scroll.setWidgetResizable(True)
+        content = QWidget()
+        scroll.setWidget(content)
+        outer.addWidget(scroll)
+
+        shell = QVBoxLayout(content)
+        shell.setContentsMargins(20, 20, 20, 20)
+        shell.setSpacing(18)
+
+        heading = QLabel("全局设置")
+        heading.setStyleSheet('font-family: "Microsoft YaHei UI"; font-size: 18pt; font-weight: 700;')
+        shell.addWidget(heading)
+
+        pivot = Pivot(dialog)
+        pivot.setFixedHeight(40)
+        shell.addWidget(pivot)
+
+        settings_stack = QStackedWidget(dialog)
+        tools_tab = QWidget(settings_stack)
+        tools_layout = QVBoxLayout(tools_tab)
+        tools_layout.setContentsMargins(0, 12, 0, 0)
+        tools_layout.setSpacing(14)
+        network_tab = QWidget(settings_stack)
+        network_layout = QVBoxLayout(network_tab)
+        network_layout.setContentsMargins(0, 12, 0, 0)
+        network_layout.setSpacing(14)
+        settings_stack.addWidget(tools_tab)
+        settings_stack.addWidget(network_tab)
+        pivot.addItem(routeKey="tools", text="工具", onClick=lambda _checked: settings_stack.setCurrentIndex(0))
+        pivot.addItem(routeKey="network", text="网络与更新", onClick=lambda _checked: settings_stack.setCurrentIndex(1))
+        pivot.setCurrentItem("tools")
+        settings_stack.setCurrentIndex(0)
+        shell.addWidget(settings_stack, 1)
+
+        ffmpeg_panel = QFrame()
+        ffmpeg_panel.setObjectName("WhitePanel")
+        ffmpeg_layout = QGridLayout(ffmpeg_panel)
+        ffmpeg_layout.setContentsMargins(14, 14, 14, 14)
+        ffmpeg_title = QLabel("FFmpeg 目录")
+        ffmpeg_title.setObjectName("PanelTitle")
+        ffmpeg_display = QLineEdit(dialog)
+        ffmpeg_display.setText(self.ffmpeg_dir_text)
+        ffmpeg_display.setPlaceholderText(FFMPEG_DIR_PLACEHOLDER)
+        choose_button = QPushButton("选择目录")
+        choose_button.clicked.connect(lambda: self._choose_ffmpeg_for_dialog(dialog, ffmpeg_display))
+        system_button = QPushButton("使用系统 PATH")
+        system_button.clicked.connect(lambda: ffmpeg_display.setText(""))
+        ffmpeg_hint_1 = QLabel("推荐选择 ffmpeg 的 bin 目录，例如 D:\\tools\\ffmpeg\\bin。")
+        ffmpeg_hint_1.setStyleSheet('font-family: "Microsoft YaHei UI"; font-size: 9pt; color: #6b7280;')
+        ffmpeg_hint_2 = QLabel("波形对齐、Hi-Res 混流和嵌入式打轴模块都会使用这里的设置。")
+        ffmpeg_hint_2.setStyleSheet('font-family: "Microsoft YaHei UI"; font-size: 9pt; color: #6b7280;')
+        ffmpeg_layout.addWidget(ffmpeg_title, 0, 0)
+        ffmpeg_layout.addWidget(ffmpeg_display, 0, 1)
+        ffmpeg_layout.addWidget(choose_button, 0, 2)
+        ffmpeg_layout.addWidget(system_button, 0, 3)
+        ffmpeg_layout.addWidget(ffmpeg_hint_1, 1, 1, 1, 3)
+        ffmpeg_layout.addWidget(ffmpeg_hint_2, 2, 1, 1, 3)
+        ffmpeg_layout.setColumnStretch(1, 1)
+        tools_layout.addWidget(ffmpeg_panel)
+        tools_layout.addStretch(1)
+
+        proxy_panel = QFrame()
+        proxy_panel.setObjectName("WhitePanel")
+        proxy_layout = QGridLayout(proxy_panel)
+        proxy_layout.setContentsMargins(14, 14, 14, 14)
+        proxy_layout.setHorizontalSpacing(12)
+        proxy_layout.setVerticalSpacing(10)
+        proxy_title = QLabel("网络与代理")
+        proxy_title.setObjectName("PanelTitle")
+        proxy_combo = StyledComboBox(dialog)
+        proxy_options = [("使用系统代理", "system"), ("自动检测代理", "auto"), ("不使用代理", "off"), ("手动指定代理", "manual")]
+        proxy_combo.addItems([label for label, _value in proxy_options])
+        for index, (_label, value) in enumerate(proxy_options):
+            if value == updater_settings.proxy_mode:
+                proxy_combo.setCurrentIndex(index)
+                break
+        self._install_single_click_combo_behavior(proxy_combo)
+        proxy_manual_edit = QLineEdit(dialog)
+        proxy_manual_edit.setText(updater_settings.proxy_manual_url)
+        proxy_manual_edit.setPlaceholderText("http://127.0.0.1:7890")
+        proxy_status_label = QLabel("")
+        proxy_status_label.setWordWrap(True)
+        proxy_status_label.setStyleSheet('font-family: "Microsoft YaHei UI"; font-size: 9pt; color: #6b7280;')
+        auto_detect_button = QPushButton("自动检测")
+        test_proxy_button = QPushButton("测试连通性")
+
+        def current_proxy_mode() -> str:
+            return proxy_options[proxy_combo.currentIndex()][1]
+
+        def resolve_proxy_status() -> tuple[str, dict[str, str] | None]:
+            try:
+                import krok_helper.lyrics_timing  # noqa: F401 - installs bundled src path
+                from strange_uta_game.updater.proxy import resolve_proxy
+
+                info, proxies = resolve_proxy(current_proxy_mode(), proxy_manual_edit.text().strip())
+                if info is not None and info.is_valid:
+                    source_names = {"system": "系统代理", "scan": "自动检测", "manual": "手动代理"}
+                    return f"当前生效代理: {info.url}（{source_names.get(info.source, info.source or '代理')}）", proxies
+                if current_proxy_mode() == "off":
+                    return "当前不使用代理。", None
+                return "当前未检测到可用代理。", None
+            except Exception as exc:  # noqa: BLE001
+                return f"代理解析失败: {exc}", None
+
+        def refresh_proxy_status() -> None:
+            text, _proxies = resolve_proxy_status()
+            proxy_status_label.setText(text)
+
+        def auto_detect_proxy() -> None:
+            previous_index = proxy_combo.currentIndex()
+            for index, (_label, value) in enumerate(proxy_options):
+                if value == "auto":
+                    proxy_combo.setCurrentIndex(index)
+                    break
+            text, _proxies = resolve_proxy_status()
+            proxy_status_label.setText(text)
+            if "未检测到" in text:
+                proxy_combo.setCurrentIndex(previous_index)
+
+        def test_proxy_connectivity() -> None:
+            proxy_status_label.setText("正在测试 GitHub API 连通性…")
+            QApplication.processEvents()
+            _text, proxies = resolve_proxy_status()
+            try:
+                import requests
+
+                response = requests.get(
+                    "https://api.github.com/repos/karaoke-studio/karaoke-studio/releases/latest",
+                    headers={"User-Agent": "KaraokeHelper-Updater/1.0"},
+                    proxies=proxies,
+                    timeout=(5, 15),
+                )
+                if response.status_code == 200:
+                    proxy_status_label.setText("连通性测试成功。")
+                else:
+                    proxy_status_label.setText(f"连通性测试失败: HTTP {response.status_code}")
+            except Exception as exc:  # noqa: BLE001
+                proxy_status_label.setText(f"连通性测试失败: {exc}")
+
+        auto_detect_button.clicked.connect(auto_detect_proxy)
+        test_proxy_button.clicked.connect(test_proxy_connectivity)
+
+        proxy_layout.addWidget(proxy_title, 0, 0)
+        proxy_layout.addWidget(QLabel("代理模式"), 1, 0)
+        proxy_layout.addWidget(proxy_combo, 1, 1, 1, 2)
+        proxy_layout.addWidget(QLabel("手动代理地址"), 2, 0)
+        proxy_layout.addWidget(proxy_manual_edit, 2, 1, 1, 2)
+        proxy_layout.addWidget(QLabel("当前生效代理"), 3, 0)
+        proxy_layout.addWidget(proxy_status_label, 3, 1)
+        proxy_layout.addWidget(auto_detect_button, 3, 2)
+        proxy_layout.addWidget(test_proxy_button, 3, 3)
+        proxy_layout.setColumnStretch(1, 1)
+        network_layout.addWidget(proxy_panel)
+
+        update_panel = QFrame()
+        update_panel.setObjectName("WhitePanel")
+        update_layout = QGridLayout(update_panel)
+        update_layout.setContentsMargins(14, 14, 14, 14)
+        update_layout.setHorizontalSpacing(12)
+        update_layout.setVerticalSpacing(10)
+        update_title = QLabel("应用更新")
+        update_title.setObjectName("PanelTitle")
+        updater_enabled_check = QCheckBox("启用工作台自动更新")
+        updater_enabled_check.setChecked(updater_settings.enabled)
+        startup_check = QCheckBox("启动时静默检查更新")
+        startup_check.setChecked(updater_settings.check_on_startup)
+        interval_edit = QLineEdit(dialog)
+        interval_edit.setText(str(updater_settings.min_check_interval_hours))
+        interval_edit.setFixedWidth(72)
+        source_order = list(updater_settings.source_order)
+        source_order_label = QLabel("")
+        source_order_label.setWordWrap(True)
+        source_order_label.setStyleSheet('font-family: "Microsoft YaHei UI"; font-size: 9pt; color: #6b7280;')
+        update_status_label = QLabel(f"当前版本 v{APP_VERSION}")
+        update_status_label.setStyleSheet('font-family: "Microsoft YaHei UI"; font-size: 9pt; color: #6b7280;')
+        edit_order_button = QPushButton("编辑顺序")
+        check_now_button = QPushButton("检查更新")
+
+        def refresh_source_order_label() -> None:
+            source_order_label.setText(" → ".join(SOURCE_LABELS.get(source, source) for source in source_order))
+
+        def edit_source_order() -> None:
+            nonlocal source_order
+            order_dialog = QDialog(dialog)
+            order_dialog.setWindowTitle("更新源优先级")
+            order_dialog.resize(520, 360)
+            order_shell = QVBoxLayout(order_dialog)
+            order_shell.setContentsMargins(16, 16, 16, 16)
+            order_shell.setSpacing(10)
+            hint = QLabel("按顺序尝试，前一项失败时自动降级到下一项。")
+            hint.setWordWrap(True)
+            order_shell.addWidget(hint)
+            order_list = QListWidget(order_dialog)
+            order_list.setDragDropMode(QAbstractItemView.DragDropMode.InternalMove)
+            order_list.setSelectionMode(QAbstractItemView.SelectionMode.SingleSelection)
+            for source in normalize_order(source_order):
+                item = QListWidgetItem(SOURCE_LABELS.get(source, source))
+                item.setData(Qt.ItemDataRole.UserRole, source)
+                order_list.addItem(item)
+            order_shell.addWidget(order_list, 1)
+            order_buttons = QHBoxLayout()
+            move_up_button = QPushButton("上移")
+            move_down_button = QPushButton("下移")
+            reset_order_button = QPushButton("恢复默认")
+            ok_button = QPushButton("确定")
+            cancel_button = QPushButton("取消")
+
+            def selected_row() -> int:
+                items = order_list.selectedItems()
+                return order_list.row(items[0]) if items else -1
+
+            def move_selected(delta: int) -> None:
+                row = selected_row()
+                target = row + delta
+                if row < 0 or target < 0 or target >= order_list.count():
+                    return
+                item = order_list.takeItem(row)
+                if item is None:
+                    return
+                order_list.insertItem(target, item)
+                order_list.setCurrentRow(target)
+
+            def reset_order() -> None:
+                order_list.clear()
+                for source in SOURCE_IDS:
+                    item = QListWidgetItem(SOURCE_LABELS.get(source, source))
+                    item.setData(Qt.ItemDataRole.UserRole, source)
+                    order_list.addItem(item)
+                order_list.setCurrentRow(0)
+
+            def accept_order() -> None:
+                nonlocal source_order
+                raw: list[str] = []
+                for row in range(order_list.count()):
+                    item = order_list.item(row)
+                    if item is not None:
+                        raw.append(str(item.data(Qt.ItemDataRole.UserRole)))
+                source_order = normalize_order(raw)
+                refresh_source_order_label()
+                order_dialog.accept()
+
+            move_up_button.clicked.connect(lambda: move_selected(-1))
+            move_down_button.clicked.connect(lambda: move_selected(1))
+            reset_order_button.clicked.connect(reset_order)
+            ok_button.clicked.connect(accept_order)
+            cancel_button.clicked.connect(order_dialog.reject)
+            order_buttons.addWidget(move_up_button)
+            order_buttons.addWidget(move_down_button)
+            order_buttons.addWidget(reset_order_button)
+            order_buttons.addStretch(1)
+            order_buttons.addWidget(ok_button)
+            order_buttons.addWidget(cancel_button)
+            order_shell.addLayout(order_buttons)
+            order_dialog.exec()
+
+        edit_order_button.clicked.connect(edit_source_order)
+        refresh_source_order_label()
+
+        def current_update_settings_from_ui() -> UpdaterSettings | None:
+            try:
+                interval = int(interval_edit.text().strip() or "0")
+                if interval < 0:
+                    raise ValueError
+            except ValueError:
+                update_status_label.setText("启动检查间隔必须是 0 或正整数。")
+                return None
+            updated = UpdaterSettings.load(self.settings)
+            updated.enabled = updater_enabled_check.isChecked()
+            updated.check_on_startup = startup_check.isChecked()
+            updated.min_check_interval_hours = interval
+            updated.proxy_mode = current_proxy_mode()
+            updated.proxy_manual_url = proxy_manual_edit.text().strip()
+            updated.source_order = normalize_order(source_order)
+            return updated
+
+        def check_now_with_current_ui() -> None:
+            settings_for_check = current_update_settings_from_ui()
+            if settings_for_check is None:
+                return
+            self._start_workbench_update_check(
+                manual=True,
+                updater_settings=settings_for_check,
+                status_label=update_status_label,
+                trigger_button=check_now_button,
+            )
+
+        check_now_button.clicked.connect(check_now_with_current_ui)
+
+        def sync_proxy_manual_enabled() -> None:
+            value = current_proxy_mode()
+            proxy_manual_edit.setEnabled(value == "manual")
+            refresh_proxy_status()
+
+        proxy_combo.currentIndexChanged.connect(lambda _index: sync_proxy_manual_enabled())
+        proxy_manual_edit.textChanged.connect(lambda _text: refresh_proxy_status())
+        sync_proxy_manual_enabled()
+
+        update_layout.addWidget(update_title, 0, 0)
+        update_layout.addWidget(updater_enabled_check, 1, 1, 1, 2)
+        update_layout.addWidget(startup_check, 2, 1, 1, 2)
+        update_layout.addWidget(QLabel("启动检查间隔"), 3, 0)
+        update_layout.addWidget(interval_edit, 3, 1)
+        update_layout.addWidget(QLabel("小时"), 3, 2)
+        update_layout.addWidget(QLabel("更新源优先级"), 4, 0)
+        update_layout.addWidget(source_order_label, 4, 1, 1, 2)
+        update_layout.addWidget(edit_order_button, 4, 3)
+        update_layout.addWidget(QLabel("立即检查更新"), 5, 0)
+        update_layout.addWidget(update_status_label, 5, 1, 1, 2)
+        update_layout.addWidget(check_now_button, 5, 3)
+        update_layout.setColumnStretch(2, 1)
+        network_layout.addWidget(update_panel)
+        network_layout.addStretch(1)
+
+        controls = QHBoxLayout()
+        controls.addStretch(1)
+        save_button = QPushButton("保存设置")
+        close_button = QPushButton("关闭")
+        close_button.clicked.connect(dialog.close)
+
+        def save_global_settings() -> None:
+            try:
+                ffmpeg_dir_text = ffmpeg_display.text().strip()
+                ffmpeg_dir = Path(ffmpeg_dir_text).expanduser() if ffmpeg_dir_text else None
+                if ffmpeg_dir is not None and not ffmpeg_dir.is_dir():
+                    raise ProcessingError("所选 ffmpeg 目录无效，请重新选择。")
+                interval = int(interval_edit.text().strip() or "0")
+                if interval < 0:
+                    raise ValueError
+            except ValueError:
+                QMessageBox.critical(dialog, APP_TITLE, "启动检查间隔必须是 0 或正整数。")
+                return
+            except ProcessingError as exc:
+                QMessageBox.critical(dialog, APP_TITLE, str(exc))
+                return
+
+            self.set_ffmpeg_dir(ffmpeg_dir or Path())
+            self.settings.ffmpeg_dir = self.ffmpeg_dir_text
+            updated = UpdaterSettings.load(self.settings)
+            updated.enabled = updater_enabled_check.isChecked()
+            updated.check_on_startup = startup_check.isChecked()
+            updated.min_check_interval_hours = interval
+            updated.proxy_mode = current_proxy_mode()
+            updated.proxy_manual_url = proxy_manual_edit.text().strip()
+            updated.source_order = normalize_order(source_order)
+            updated.save(self.settings)
+            update_status_label.setText("设置已保存到本地。")
+
+        save_button.clicked.connect(save_global_settings)
+        controls.addWidget(save_button)
+        controls.addWidget(close_button)
+        shell.addLayout(controls)
+        dialog.exec()
+
+    def _check_for_workbench_update_on_startup(self) -> None:
+        settings = ensure_updater_settings(self.settings)
+        self._start_workbench_update_check(manual=False, updater_settings=settings)
+
+    def _start_workbench_update_check(
+        self,
+        *,
+        manual: bool,
+        updater_settings: UpdaterSettings | None = None,
+        status_label: QLabel | None = None,
+        trigger_button: QPushButton | None = None,
+    ) -> None:
+        settings = updater_settings or UpdaterSettings.load(self.settings)
+        if not manual and (not settings.enabled or not settings.check_on_startup):
+            return
+        if self._update_checker is not None:
+            return
+        if status_label is not None:
+            status_label.setText("正在检查更新…")
+        if trigger_button is not None:
+            trigger_button.setEnabled(False)
+        checker = UpdateChecker(settings, manual=manual, parent=self)
+        self._update_checker = checker
+
+        def finish(result: object) -> None:
+            if self._update_checker is checker:
+                self._update_checker = None
+            if trigger_button is not None:
+                trigger_button.setEnabled(True)
+            self._handle_workbench_update_result(
+                result,
+                manual=manual,
+                checker_settings=settings,
+                status_label=status_label,
+            )
+
+        checker.finished.connect(finish)
+        checker.start()
+
+    def _handle_workbench_update_result(
+        self,
+        result: object,
+        *,
+        manual: bool,
+        checker_settings: UpdaterSettings,
+        status_label: QLabel | None = None,
+    ) -> None:
+        if not isinstance(result, CheckResult):
+            if manual:
+                QMessageBox.critical(self, APP_TITLE, "检查更新失败：返回结果无效。")
+            return
+        checker_settings.save(self.settings)
+        if result.skipped_due_to_cooldown:
+            if status_label is not None:
+                status_label.setText(f"当前版本 v{APP_VERSION}")
+            return
+        if not result.ok:
+            if status_label is not None:
+                status_label.setText("检查更新失败。")
+            if manual:
+                details = "\n".join(
+                    f"[{'OK' if not err else 'FAIL'}] {source} - {url}\n{err}"
+                    for source, url, err in result.attempts
+                )
+                QMessageBox.critical(self, APP_TITLE, f"{result.error}\n\n{details}" if details else result.error)
+            return
+        if not result.has_update or result.release is None:
+            if status_label is not None:
+                remote = result.release.version if result.release is not None else APP_VERSION
+                status_label.setText(f"已是最新版本。当前 v{APP_VERSION}，远端 v{remote}。")
+            elif manual:
+                QMessageBox.information(self, APP_TITLE, f"当前已经是最新版本：v{APP_VERSION}")
+            return
+        if status_label is not None:
+            status_label.setText(f"发现新版本 v{result.release.version}")
+        self._show_workbench_update_dialog(result, checker_settings)
+
+    def _show_workbench_update_dialog(self, result: CheckResult, settings: UpdaterSettings) -> None:
+        release = result.release
+        if release is None:
+            return
+        message = QMessageBox(self)
+        message.setWindowTitle(APP_TITLE)
+        message.setIcon(QMessageBox.Icon.Information)
+        source_label = SOURCE_LABELS.get(result.primary_source, result.primary_source)
+        message.setText(f"发现工作台新版本 v{release.version}")
+        message.setInformativeText(
+            f"当前版本 v{APP_VERSION}\n发布于 {release.published_at[:10] or '未知日期'}\n下载源：{source_label}"
+        )
+        if release.body.strip():
+            message.setDetailedText(release.body.strip())
+        update_button = message.addButton("立即更新", QMessageBox.ButtonRole.AcceptRole)
+        skip_button = message.addButton("跳过此版本", QMessageBox.ButtonRole.DestructiveRole)
+        later_button = message.addButton("稍后再说", QMessageBox.ButtonRole.RejectRole)
+        message.exec()
+
+        clicked = message.clickedButton()
+        if clicked is skip_button:
+            settings.skipped_version = release.version
+            settings.save(self.settings)
+            return
+        if clicked is later_button:
+            return
+        if clicked is update_button:
+            self._launch_workbench_updater(result)
+
+    def _launch_workbench_updater(self, result: CheckResult) -> None:
+        if not result.release or not result.download_candidates:
+            QMessageBox.critical(self, APP_TITLE, "缺少更新下载信息，请到 GitHub Release 手动下载。")
+            return
+        try:
+            import krok_helper.lyrics_timing  # noqa: F401 - installs bundled src path
+            from strange_uta_game.updater import installer
+        except Exception as exc:  # noqa: BLE001
+            QMessageBox.critical(self, APP_TITLE, f"无法加载更新器：\n{exc}")
+            return
+        if not installer.is_updater_available():
+            QMessageBox.information(self, APP_TITLE, "缺少 Updater.exe。请到 GitHub Release 手动下载最新版本。")
+            return
+        proxy_settings = UpdaterSettings.load(self.settings)
+        proxy_url = ""
+        if proxy_settings.proxy_mode == "manual" and proxy_settings.proxy_manual_url.strip():
+            proxy_url = proxy_settings.proxy_manual_url.strip()
+            if "://" not in proxy_url:
+                proxy_url = f"http://{proxy_url}"
+        plan = installer.LaunchPlan(
+            app_dir=installer.find_app_dir(),
+            app_exe_name=installer.find_app_exe_name(),
+            target_version=result.release.version,
+            target_tag=result.release.tag,
+            asset_name=result.primary_asset_name,
+            download_urls=[(source, url) for source, url in result.download_candidates],
+            proxy_url=proxy_url,
+        )
+        launch_result = installer.launch_updater(plan)
+        if not launch_result.launched:
+            QMessageBox.critical(self, APP_TITLE, f"无法启动 Updater：\n{launch_result.reason}")
+            return
+        QApplication.quit()
 
     def _save_settings_payload(
         self,

--- a/krok_helper/lyrics_timing/src/strange_uta_game/frontend/settings/settings_interface.py
+++ b/krok_helper/lyrics_timing/src/strange_uta_game/frontend/settings/settings_interface.py
@@ -123,6 +123,11 @@ class SettingsInterface(ScrollArea):
         self._store = None
         self._settings_provider = settings_provider
         self._settings = AppSettings(provider=settings_provider)
+        self._embedded = settings_provider is not None
+        self._tab_config = [
+            item for item in self.TAB_CONFIG
+            if not (self._embedded and item[0] == "network")
+        ]
         self._initialized = False       # True = _preload 已调度（但可能还未完成）
         self._fully_initialized = False  # True = 所有子页面全部创建并连接完毕
 
@@ -197,7 +202,7 @@ class SettingsInterface(ScrollArea):
         self.pivot.setFixedHeight(40)
         self.vBoxLayout.addWidget(self.pivot)
 
-        for key, text in self.TAB_CONFIG:
+        for key, text in self._tab_config:
             self.pivot.addItem(
                 routeKey=key,
                 text=text,
@@ -206,7 +211,7 @@ class SettingsInterface(ScrollArea):
 
         self.vBoxLayout.addWidget(self.stackedWidget)
 
-        self.pivot.setCurrentItem(self.TAB_CONFIG[0][0])
+        self.pivot.setCurrentItem(self._tab_config[0][0])
         self.stackedWidget.setCurrentIndex(0)
 
     def _preload(self):
@@ -229,7 +234,7 @@ class SettingsInterface(ScrollArea):
         self.uiInterface        = UISubInterface(self)
         self.exportInterface    = ExportSubInterface(self)
         self.shortcutInterface  = ShortcutSubInterface(self)
-        self.networkInterface   = NetworkSubInterface(self)
+        self.networkInterface   = None if self._embedded else NetworkSubInterface(self)
         self.aboutInterface     = AboutSubInterface(self)
 
         QTimer.singleShot(0, self._preload_finalize)
@@ -237,12 +242,15 @@ class SettingsInterface(ScrollArea):
     def _preload_finalize(self):
         """第三批：连接信号、加载设置、注入 updater UI。"""
         # 把所有子页面按顺序加入 stackedWidget
-        for iface in [
+        interfaces = [
             self.playbackInterface, self.timingInterface, self.autoSaveInterface,
             self.autoCheckInterface, self.dictionaryInterface, self.uiInterface,
-            self.exportInterface, self.shortcutInterface, self.networkInterface,
+            self.exportInterface, self.shortcutInterface,
             self.aboutInterface,
-        ]:
+        ]
+        if self.networkInterface is not None:
+            interfaces.insert(-1, self.networkInterface)
+        for iface in interfaces:
             self.stackedWidget.addWidget(iface)
 
         # 传入 store（若已由外层设置）
@@ -267,14 +275,15 @@ class SettingsInterface(ScrollArea):
         self._load_current_settings()
 
         # 注入 updater UI（只在初始化阶段执行一次）
-        self.networkInterface.attach_updater_ui(self._settings)
+        if self.networkInterface is not None:
+            self.networkInterface.attach_updater_ui(self._settings)
 
         self._fully_initialized = True
 
     # ── 选项卡切换 ────────────────────────────────────────────────────
 
     def _on_tab_changed(self, routeKey: str):
-        tab_map = {k: i for i, (k, _) in enumerate(self.TAB_CONFIG)}
+        tab_map = {k: i for i, (k, _) in enumerate(self._tab_config)}
         self.stackedWidget.setCurrentIndex(tab_map.get(routeKey, 0))
 
     # ── 外部接口 ──────────────────────────────────────────────────────
@@ -329,7 +338,8 @@ class SettingsInterface(ScrollArea):
                 self.exportInterface, self.shortcutInterface, self.aboutInterface,
             ]:
                 iface.load_settings(s)
-            self.networkInterface.load_settings(s)
+            if self.networkInterface is not None:
+                self.networkInterface.load_settings(s)
             self._apply_theme_setting()
         finally:
             self._loading_settings = False

--- a/krok_helper/lyrics_timing/src/strange_uta_game/frontend/settings/sub_interfaces/network.py
+++ b/krok_helper/lyrics_timing/src/strange_uta_game/frontend/settings/sub_interfaces/network.py
@@ -31,6 +31,8 @@ class NetworkSubInterface(SubSettingInterface):
             return
         self._settings_ref = settings
         self._updater_attached = True
+        if getattr(settings, "_provider", None) is not None:
+            return
         try:
             from strange_uta_game.updater.ui import attach_proxy_group, attach_update_group
             attach_proxy_group(self)

--- a/krok_helper/settings.py
+++ b/krok_helper/settings.py
@@ -54,6 +54,7 @@ class AppSettings:
     video_download_retry_count: int = 3
     video_download_cookie_path: str = ""
     video_download_source: str = SOURCE_YOUTUBE
+    updater: dict = field(default_factory=dict)
 
     # ── 歌词打轴模块（StrangeUtaGame）的设置 namespace ──
     # 由 frontend/settings/app_settings.py 中 AppSettings 的 dotted-key 树
@@ -139,6 +140,7 @@ def load_app_settings() -> AppSettings:
         video_download_retry_count=min(5, max(1, int(payload.get("video_download_retry_count", 3) or 3))),
         video_download_cookie_path=str(payload.get("video_download_cookie_path", "")),
         video_download_source=str(payload.get("video_download_source", SOURCE_YOUTUBE)),
+        updater=_safe_dict(payload.get("updater")),
         lyrics_timing=_safe_dict(payload.get("lyrics_timing")),
         lyrics_timing_dictionary=_safe_list(payload.get("lyrics_timing_dictionary")),
         lyrics_timing_singers=_safe_list(payload.get("lyrics_timing_singers")),

--- a/krok_helper/updater/__init__.py
+++ b/krok_helper/updater/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from .settings import UpdaterSettings, ensure_updater_settings
+from .worker import CheckResult, UpdateChecker
+
+__all__ = [
+    "CheckResult",
+    "UpdateChecker",
+    "UpdaterSettings",
+    "ensure_updater_settings",
+]

--- a/krok_helper/updater/settings.py
+++ b/krok_helper/updater/settings.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from krok_helper.settings import AppSettings, save_app_settings
+from krok_helper.updater.sources import DEFAULT_ORDER, SourceId, normalize_order
+
+DEFAULT_MIN_CHECK_INTERVAL_HOURS = 8
+
+DEFAULTS: dict[str, Any] = {
+    "enabled": True,
+    "check_on_startup": True,
+    "min_check_interval_hours": DEFAULT_MIN_CHECK_INTERVAL_HOURS,
+    "source_order": list(DEFAULT_ORDER),
+    "proxy": {
+        "mode": "system",
+        "manual_url": "",
+    },
+    "skipped_version": "",
+    "last_seen_version": "",
+    "last_check_at": 0,
+}
+
+
+@dataclass
+class UpdaterSettings:
+    enabled: bool = True
+    check_on_startup: bool = True
+    min_check_interval_hours: int = DEFAULT_MIN_CHECK_INTERVAL_HOURS
+    source_order: list[SourceId] = field(default_factory=lambda: list(DEFAULT_ORDER))
+    proxy_mode: str = "system"
+    proxy_manual_url: str = ""
+    skipped_version: str = ""
+    last_seen_version: str = ""
+    last_check_at: int = 0
+
+    @classmethod
+    def load(cls, app_settings: AppSettings) -> "UpdaterSettings":
+        raw = app_settings.updater if isinstance(app_settings.updater, dict) else {}
+        merged: dict[str, Any] = {}
+        for key, value in DEFAULTS.items():
+            if isinstance(value, dict):
+                current = raw.get(key, {})
+                merged[key] = {**value, **(current if isinstance(current, dict) else {})}
+            else:
+                merged[key] = raw.get(key, value)
+        proxy = merged.get("proxy") if isinstance(merged.get("proxy"), dict) else {}
+        return cls(
+            enabled=bool(merged.get("enabled", True)),
+            check_on_startup=bool(merged.get("check_on_startup", True)),
+            min_check_interval_hours=max(0, int(merged.get("min_check_interval_hours", DEFAULT_MIN_CHECK_INTERVAL_HOURS) or 0)),
+            source_order=normalize_order(merged.get("source_order") or []),
+            proxy_mode=str(proxy.get("mode", "system")),
+            proxy_manual_url=str(proxy.get("manual_url", "")),
+            skipped_version=str(merged.get("skipped_version", "")),
+            last_seen_version=str(merged.get("last_seen_version", "")),
+            last_check_at=int(merged.get("last_check_at", 0) or 0),
+        )
+
+    def save(self, app_settings: AppSettings) -> None:
+        app_settings.updater = self.to_payload()
+        save_app_settings(app_settings)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "enabled": self.enabled,
+            "check_on_startup": self.check_on_startup,
+            "min_check_interval_hours": int(self.min_check_interval_hours),
+            "source_order": list(self.source_order),
+            "proxy": {
+                "mode": self.proxy_mode,
+                "manual_url": self.proxy_manual_url,
+            },
+            "skipped_version": self.skipped_version,
+            "last_seen_version": self.last_seen_version,
+            "last_check_at": int(self.last_check_at),
+        }
+
+    def is_within_check_cooldown(self, now: float | None = None) -> bool:
+        if self.min_check_interval_hours <= 0 or self.last_check_at <= 0:
+            return False
+        now = time.time() if now is None else now
+        return now - self.last_check_at < self.min_check_interval_hours * 3600
+
+
+def ensure_updater_settings(app_settings: AppSettings) -> UpdaterSettings:
+    raw = app_settings.updater
+    settings = UpdaterSettings.load(app_settings)
+    if (
+        not isinstance(raw, dict)
+        or "enabled" not in raw
+        or "source_order" not in raw
+        or "min_check_interval_hours" not in raw
+        or "last_check_at" not in raw
+    ):
+        settings.save(app_settings)
+    return settings

--- a/krok_helper/updater/sources.py
+++ b/krok_helper/updater/sources.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from typing import Literal
+
+REPO_OWNER = "karaoke-studio"
+REPO_NAME = "karaoke-studio"
+
+SourceId = Literal["github", "ghproxy", "gh-proxy", "ghproxy-net"]
+SOURCE_IDS: tuple[SourceId, ...] = ("github", "ghproxy", "gh-proxy", "ghproxy-net")
+SOURCE_LABELS: dict[SourceId, str] = {
+    "github": "GitHub Release（官方）",
+    "ghproxy": "GitHub Proxy（mirror.ghproxy.com）",
+    "gh-proxy": "GitHub Proxy（gh-proxy.com）",
+    "ghproxy-net": "GitHub Proxy（ghproxy.net）",
+}
+DEFAULT_ORDER: list[SourceId] = list(SOURCE_IDS)
+
+
+def normalize_order(order: list[str] | tuple[str, ...]) -> list[SourceId]:
+    seen: list[SourceId] = []
+    for value in order:
+        if value in SOURCE_IDS and value not in seen:
+            seen.append(value)  # type: ignore[arg-type]
+    for value in DEFAULT_ORDER:
+        if value not in seen:
+            seen.append(value)
+    return seen
+
+
+def build_download_url(source: SourceId, tag: str, asset_name: str) -> str:
+    path = f"{REPO_OWNER}/{REPO_NAME}/releases/download/{tag}/{asset_name}"
+    if source == "github":
+        return f"https://github.com/{path}"
+    if source == "ghproxy":
+        return f"https://mirror.ghproxy.com/https://github.com/{path}"
+    if source == "gh-proxy":
+        return f"https://gh-proxy.com/https://github.com/{path}"
+    if source == "ghproxy-net":
+        return f"https://ghproxy.net/https://github.com/{path}"
+    raise ValueError(f"未知的更新源 id: {source!r}")
+
+
+def build_release_urls(order: list[str] | tuple[str, ...], tag: str, asset_name: str) -> list[tuple[SourceId, str]]:
+    return [(source, build_download_url(source, tag, asset_name)) for source in normalize_order(order)]
+
+
+def build_api_urls(order: list[str] | tuple[str, ...]) -> list[tuple[SourceId, str]]:
+    api_path = f"repos/{REPO_OWNER}/{REPO_NAME}/releases/latest"
+    urls: list[tuple[SourceId, str]] = []
+    for source in normalize_order(order):
+        if source == "github":
+            urls.append((source, f"https://api.github.com/{api_path}"))
+        elif source == "ghproxy":
+            urls.append((source, f"https://mirror.ghproxy.com/https://api.github.com/{api_path}"))
+        elif source == "gh-proxy":
+            urls.append((source, f"https://gh-proxy.com/https://api.github.com/{api_path}"))
+        elif source == "ghproxy-net":
+            urls.append((source, f"https://ghproxy.net/https://api.github.com/{api_path}"))
+    return urls

--- a/krok_helper/updater/worker.py
+++ b/krok_helper/updater/worker.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from PyQt6.QtCore import QObject, QThread, pyqtSignal
+
+from krok_helper.config import APP_VERSION
+from krok_helper.updater.settings import UpdaterSettings
+from krok_helper.updater.sources import SourceId, build_api_urls, build_release_urls
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ReleaseAsset:
+    name: str
+    size: int
+    download_url: str
+
+
+@dataclass(frozen=True)
+class LatestRelease:
+    tag: str
+    version: str
+    name: str
+    body: str
+    html_url: str
+    prerelease: bool
+    published_at: str
+    assets: list[ReleaseAsset] = field(default_factory=list)
+
+    def pick_primary_asset(self, preferred_name: str) -> ReleaseAsset | None:
+        for asset in self.assets:
+            if asset.name == preferred_name:
+                return asset
+        platform_key = "windows" if sys.platform == "win32" else "macos" if sys.platform == "darwin" else ""
+        if platform_key:
+            for asset in self.assets:
+                if platform_key in asset.name.lower() and asset.name.lower().endswith(".zip"):
+                    return asset
+        for asset in self.assets:
+            if asset.name.lower().endswith(".zip"):
+                return asset
+        return None
+
+
+@dataclass
+class CheckResult:
+    ok: bool
+    has_update: bool = False
+    release: LatestRelease | None = None
+    primary_url: str = ""
+    primary_source: str = ""
+    primary_asset_name: str = ""
+    download_candidates: list[tuple[SourceId, str]] = field(default_factory=list)
+    attempts: list[tuple[SourceId, str, str]] = field(default_factory=list)
+    error: str = ""
+    skipped_due_to_cooldown: bool = False
+
+
+def _strip_tag_prefix(tag: str) -> str:
+    value = tag.strip()
+    if value.lower().startswith("v"):
+        return value[1:]
+    return value
+
+
+def _version_key(value: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for chunk in _strip_tag_prefix(value).replace("-", ".").split("."):
+        digits = ""
+        for char in chunk:
+            if char.isdigit():
+                digits += char
+            else:
+                break
+        parts.append(int(digits or 0))
+    while len(parts) < 3:
+        parts.append(0)
+    return tuple(parts)
+
+
+def is_newer_version(remote: str, local: str = APP_VERSION) -> bool:
+    return _version_key(remote) > _version_key(local)
+
+
+def current_asset_name() -> str:
+    if sys.platform == "darwin":
+        return "KaraokeHelper-macos.zip"
+    return "KaraokeHelper-windows.zip"
+
+
+def _parse_release(payload: dict[str, Any]) -> LatestRelease:
+    assets: list[ReleaseAsset] = []
+    for raw_asset in payload.get("assets") or []:
+        if not isinstance(raw_asset, dict):
+            continue
+        name = str(raw_asset.get("name") or "")
+        if not name:
+            continue
+        assets.append(
+            ReleaseAsset(
+                name=name,
+                size=int(raw_asset.get("size") or 0),
+                download_url=str(raw_asset.get("browser_download_url") or ""),
+            )
+        )
+    tag = str(payload.get("tag_name") or "")
+    return LatestRelease(
+        tag=tag,
+        version=_strip_tag_prefix(tag),
+        name=str(payload.get("name") or "") or tag,
+        body=str(payload.get("body") or ""),
+        html_url=str(payload.get("html_url") or ""),
+        prerelease=bool(payload.get("prerelease") or False),
+        published_at=str(payload.get("published_at") or ""),
+        assets=assets,
+    )
+
+
+def _proxies_for(settings: UpdaterSettings) -> dict[str, str] | None:
+    try:
+        import krok_helper.lyrics_timing  # noqa: F401 - installs bundled src path
+        from strange_uta_game.updater.proxy import resolve_proxy
+
+        _info, proxies = resolve_proxy(settings.proxy_mode, settings.proxy_manual_url)
+        return proxies
+    except Exception:
+        if settings.proxy_mode == "off":
+            return {}
+        if settings.proxy_mode == "manual" and settings.proxy_manual_url.strip():
+            url = settings.proxy_manual_url.strip()
+            if "://" not in url:
+                url = f"http://{url}"
+            return {"http": url, "https": url}
+        return None
+
+
+def fetch_latest_release(
+    settings: UpdaterSettings,
+) -> tuple[LatestRelease | None, list[tuple[SourceId, str, str]]]:
+    attempts: list[tuple[SourceId, str, str]] = []
+    proxies = _proxies_for(settings)
+    for source, url in build_api_urls(settings.source_order):
+        try:
+            import requests
+
+            response = requests.get(
+                url,
+                headers={"User-Agent": "KaraokeHelper-Updater/1.0", "Accept": "application/json"},
+                proxies=proxies,
+                timeout=(5, 20),
+                allow_redirects=True,
+            )
+            if response.status_code != 200:
+                attempts.append((source, url, f"HTTP {response.status_code}"))
+                continue
+            payload = response.json()
+            if not isinstance(payload, dict):
+                attempts.append((source, url, "响应不是 JSON 对象"))
+                continue
+            release = _parse_release(payload)
+            if not release.tag:
+                attempts.append((source, url, "缺少 tag_name"))
+                continue
+            if release.prerelease:
+                attempts.append((source, url, "命中预发布版本，已跳过"))
+                continue
+            attempts.append((source, url, ""))
+            return release, attempts
+        except Exception as exc:  # noqa: BLE001
+            attempts.append((source, url, str(exc)))
+    return None, attempts
+
+
+class _CheckRunnable(QObject):
+    finished = pyqtSignal(object)
+
+    def __init__(self, settings: UpdaterSettings, manual: bool = False):
+        super().__init__()
+        self._settings = settings
+        self._manual = manual
+
+    def run(self) -> None:
+        try:
+            result = self._do_check()
+        except Exception as exc:  # noqa: BLE001
+            log.exception("更新检查异常")
+            result = CheckResult(ok=False, error=f"检查异常: {exc}")
+        self.finished.emit(result)
+
+    def _do_check(self) -> CheckResult:
+        if not self._settings.enabled:
+            return CheckResult(ok=False, error="更新功能已禁用")
+        if not self._manual and not self._settings.check_on_startup:
+            return CheckResult(ok=False, skipped_due_to_cooldown=True)
+        if not self._manual and self._settings.is_within_check_cooldown():
+            return CheckResult(ok=True, skipped_due_to_cooldown=True)
+
+        release, attempts = fetch_latest_release(self._settings)
+        if release is None:
+            return CheckResult(ok=False, error="无法访问任何更新源（请检查网络/代理）", attempts=attempts)
+
+        self._settings.last_check_at = int(time.time())
+        self._settings.last_seen_version = release.version
+        preferred_asset = current_asset_name()
+        asset = release.pick_primary_asset(preferred_asset)
+        candidates: list[tuple[SourceId, str]] = []
+        primary_source = ""
+        primary_url = ""
+        asset_name = asset.name if asset is not None else preferred_asset
+        if asset is not None:
+            candidates = build_release_urls(self._settings.source_order, release.tag, asset_name)
+            if candidates:
+                primary_source, primary_url = candidates[0]
+
+        has_update = is_newer_version(release.version, APP_VERSION) and asset is not None
+        if has_update and not self._manual and self._settings.skipped_version == release.version:
+            has_update = False
+        return CheckResult(
+            ok=True,
+            has_update=has_update,
+            release=release,
+            primary_url=primary_url,
+            primary_source=primary_source,
+            primary_asset_name=asset_name,
+            download_candidates=candidates,
+            attempts=attempts,
+        )
+
+
+class UpdateChecker(QObject):
+    finished = pyqtSignal(object)
+
+    def __init__(self, settings: UpdaterSettings, manual: bool = False, parent: QObject | None = None):
+        super().__init__(parent)
+        self._settings = settings
+        self._manual = manual
+        self._thread: QThread | None = None
+        self._worker: _CheckRunnable | None = None
+
+    def start(self) -> None:
+        if self._thread is not None and self._thread.isRunning():
+            return
+        self._thread = QThread()
+        self._worker = _CheckRunnable(self._settings, self._manual)
+        self._worker.moveToThread(self._thread)
+        self._thread.started.connect(self._worker.run)
+        self._worker.finished.connect(self._on_finished)
+        self._worker.finished.connect(self._thread.quit)
+        self._thread.finished.connect(self._worker.deleteLater)
+        self._thread.finished.connect(self._cleanup)
+        self._thread.start()
+
+    def _on_finished(self, result: object) -> None:
+        self.finished.emit(result)
+
+    def _cleanup(self) -> None:
+        if self._thread is not None:
+            self._thread.deleteLater()
+        self._thread = None
+        self._worker = None

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -27,6 +27,21 @@ call :ensure_pkg PyInstaller pyinstaller || exit /b 1
 call :ensure_pkg PyQt6 PyQt6 || exit /b 1
 call :ensure_pkg qfluentwidgets "PyQt6-Fluent-Widgets" || exit /b 1
 call :ensure_pkg yt_dlp yt-dlp || exit /b 1
+call :ensure_pkg requests requests || exit /b 1
+
+if not exist "krok_helper\lyrics_timing\updater_app\dist\Updater.exe" (
+    echo Building Updater.exe...
+    pushd krok_helper\lyrics_timing
+    %PYTHON_BIN% updater_app\build_updater.py
+    if errorlevel 1 (
+        popd
+        echo.
+        echo Updater build failed.
+        if not defined IS_CI pause
+        exit /b 1
+    )
+    popd
+)
 
 if not exist "%DIST_PATH%" mkdir "%DIST_PATH%"
 if not exist "%WORK_PATH%" mkdir "%WORK_PATH%"
@@ -131,6 +146,18 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command ^
 if errorlevel 1 (
     echo.
     echo Package rename failed.
+    if not defined IS_CI pause
+    exit /b 1
+)
+
+echo Copying Updater.exe...
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+    "$targetDir = Resolve-Path '%APP_DIST%';" ^
+    "$updater = Resolve-Path 'krok_helper\lyrics_timing\updater_app\dist\Updater.exe';" ^
+    "Copy-Item -LiteralPath $updater -Destination (Join-Path $targetDir 'Updater.exe') -Force"
+if errorlevel 1 (
+    echo.
+    echo Failed to copy Updater.exe.
     if not defined IS_CI pause
     exit /b 1
 )

--- a/tests/test_workbench_updater.py
+++ b/tests/test_workbench_updater.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+
+from krok_helper.settings import AppSettings
+from krok_helper.updater.settings import UpdaterSettings, ensure_updater_settings
+from krok_helper.updater.sources import build_api_urls, build_release_urls, normalize_order
+from krok_helper.updater.worker import LatestRelease, ReleaseAsset, current_asset_name, is_newer_version
+
+
+def test_workbench_updater_uses_workbench_repo_urls() -> None:
+    api_urls = build_api_urls(["github"])
+    release_urls = build_release_urls(["github"], "v3.0.1", "KaraokeHelper-windows.zip")
+
+    assert api_urls[0][1] == "https://api.github.com/repos/karaoke-studio/karaoke-studio/releases/latest"
+    assert release_urls[0][1] == (
+        "https://github.com/karaoke-studio/karaoke-studio/"
+        "releases/download/v3.0.1/KaraokeHelper-windows.zip"
+    )
+
+
+def test_workbench_updater_settings_roundtrip_defaults() -> None:
+    settings = AppSettings()
+
+    updater = ensure_updater_settings(settings)
+
+    assert updater.enabled is True
+    assert updater.check_on_startup is True
+    assert settings.updater["source_order"] == ["github", "ghproxy", "gh-proxy", "ghproxy-net"]
+    assert UpdaterSettings.load(settings).min_check_interval_hours == 8
+
+
+def test_workbench_updater_normalizes_source_order() -> None:
+    assert normalize_order(["ghproxy", "bogus", "github", "ghproxy"]) == [
+        "ghproxy",
+        "github",
+        "gh-proxy",
+        "ghproxy-net",
+    ]
+
+
+def test_workbench_updater_version_and_asset_selection(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    release = LatestRelease(
+        tag="v3.0.1",
+        version="3.0.1",
+        name="v3.0.1",
+        body="",
+        html_url="",
+        prerelease=False,
+        published_at="",
+        assets=[ReleaseAsset("KaraokeHelper-windows.zip", 10, "https://example.invalid/app.zip")],
+    )
+
+    assert is_newer_version("3.0.1", "3.0.0")
+    assert current_asset_name() == "KaraokeHelper-windows.zip"
+    assert release.pick_primary_asset("KaraokeHelper-windows.zip") is not None


### PR DESCRIPTION
﻿## What changed

- Added a workbench-level global settings entry in the workflow header.
- Moved FFmpeg configuration into global settings and wired it to waveform alignment, Hi-Res mixing, and embedded SUG runtime paths.
- Added workbench update settings, GitHub Release checking, proxy controls, update-source ordering, and Windows packaging support for Updater.exe.
- Removed the SUG network/update settings tab when SUG runs embedded in the workbench.

## Why

The workbench owns the packaged executable, so automatic updates must target the whole workbench release instead of the embedded SUG module. FFmpeg should also be a single host-managed setting instead of repeated per module.

## Validation

- `python -m compileall krok_helper`
- `python -m pytest tests\test_workbench_updater.py tests\test_ffmpeg_paths.py -q`

Note: the older SUG namespace test still needs the SUG runtime dependencies such as `numpy` installed in this environment.
