### PR TITLE
fix: route embedded SUG shortcuts

### DIFF
--- a/krok_helper/gui_qt.py
+++ b/krok_helper/gui_qt.py
@@ -2390,6 +2390,7 @@ class KrokHelperQtApp(QMainWindow):
         self._sync_page_stack_margins(module_id)
         self.page_stack.setCurrentWidget(self.module_pages[module_id])
         self.workflow_stepper.setCurrentModule(module_id)
+        self._sync_workflow_shortcut_scope()
 
     def _sync_page_stack_margins(self, module_id: str) -> None:
         layout = getattr(self, "_page_stack_container_layout", None)
@@ -2421,11 +2422,22 @@ class KrokHelperQtApp(QMainWindow):
         self.shortcut_space = QShortcut(QKeySequence(Qt.Key.Key_Space), self)
         self.shortcut_space.activated.connect(self._handle_align_space_shortcut)
         self.shortcut_export = QShortcut(QKeySequence("Ctrl+S"), self)
-        self.shortcut_export.activated.connect(self._handle_align_export_shortcut)
+        self.shortcut_export.activated.connect(self._handle_export_or_save_shortcut)
         self.shortcut_auto = QShortcut(QKeySequence("Ctrl+D"), self)
         self.shortcut_auto.activated.connect(self._handle_align_auto_shortcut)
         self.shortcut_drag_mode = QShortcut(QKeySequence("Alt+V"), self)
         self.shortcut_drag_mode.activated.connect(self._handle_align_drag_mode_shortcut)
+        self._sync_workflow_shortcut_scope()
+
+    def _sync_workflow_shortcut_scope(self) -> None:
+        if not hasattr(self, "shortcut_space"):
+            return
+        align_active = self.active_module == WORKFLOW_WAVEFORM_ALIGN
+        timing_active = self.active_module == WORKFLOW_LYRICS_TIMING
+        self.shortcut_space.setEnabled(align_active)
+        self.shortcut_auto.setEnabled(align_active)
+        self.shortcut_drag_mode.setEnabled(align_active)
+        self.shortcut_export.setEnabled(align_active or timing_active)
 
     def _focused_widget_is_text_input(self) -> bool:
         widget = QApplication.focusWidget()
@@ -2442,7 +2454,12 @@ class KrokHelperQtApp(QMainWindow):
         else:
             self._start_alignment_analysis()
 
-    def _handle_align_export_shortcut(self) -> None:
+    def _handle_export_or_save_shortcut(self) -> None:
+        if self.active_module == WORKFLOW_LYRICS_TIMING:
+            lyrics_timing_page = getattr(self, "lyrics_timing_page", None)
+            if lyrics_timing_page is not None and hasattr(lyrics_timing_page, "trigger_save"):
+                lyrics_timing_page.trigger_save()
+            return
         if self.active_module != WORKFLOW_WAVEFORM_ALIGN or self._focused_widget_is_text_input():
             return
         self._start_aligned_export()

--- a/tests/test_sug_embedded_shortcuts.py
+++ b/tests/test_sug_embedded_shortcuts.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from krok_helper.gui_qt import (
+    KrokHelperQtApp,
+    WORKFLOW_HIRES_MIX,
+    WORKFLOW_LYRICS_TIMING,
+    WORKFLOW_WAVEFORM_ALIGN,
+)
+
+
+class _FakeShortcut:
+    def __init__(self) -> None:
+        self.enabled: bool | None = None
+
+    def setEnabled(self, enabled: bool) -> None:  # noqa: N802 - Qt-style API
+        self.enabled = enabled
+
+
+class _FakeTimingPage:
+    def __init__(self) -> None:
+        self.save_count = 0
+
+    def trigger_save(self) -> None:
+        self.save_count += 1
+
+
+def _fake_app(module_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        active_module=module_id,
+        shortcut_space=_FakeShortcut(),
+        shortcut_auto=_FakeShortcut(),
+        shortcut_drag_mode=_FakeShortcut(),
+        shortcut_export=_FakeShortcut(),
+    )
+
+
+def test_host_space_shortcut_is_disabled_on_embedded_timing_page() -> None:
+    app = _fake_app(WORKFLOW_LYRICS_TIMING)
+
+    KrokHelperQtApp._sync_workflow_shortcut_scope(app)
+
+    assert app.shortcut_space.enabled is False
+    assert app.shortcut_auto.enabled is False
+    assert app.shortcut_drag_mode.enabled is False
+    assert app.shortcut_export.enabled is True
+
+
+def test_host_alignment_shortcuts_only_enabled_on_alignment_page() -> None:
+    app = _fake_app(WORKFLOW_WAVEFORM_ALIGN)
+
+    KrokHelperQtApp._sync_workflow_shortcut_scope(app)
+
+    assert app.shortcut_space.enabled is True
+    assert app.shortcut_auto.enabled is True
+    assert app.shortcut_drag_mode.enabled is True
+    assert app.shortcut_export.enabled is True
+
+
+def test_host_shortcuts_do_not_consume_unrelated_pages() -> None:
+    app = _fake_app(WORKFLOW_HIRES_MIX)
+
+    KrokHelperQtApp._sync_workflow_shortcut_scope(app)
+
+    assert app.shortcut_space.enabled is False
+    assert app.shortcut_auto.enabled is False
+    assert app.shortcut_drag_mode.enabled is False
+    assert app.shortcut_export.enabled is False
+
+
+def test_ctrl_s_routes_to_embedded_sug_save() -> None:
+    timing_page = _FakeTimingPage()
+    app = SimpleNamespace(
+        active_module=WORKFLOW_LYRICS_TIMING,
+        lyrics_timing_page=timing_page,
+    )
+
+    KrokHelperQtApp._handle_export_or_save_shortcut(app)
+
+    assert timing_page.save_count == 1


### PR DESCRIPTION
﻿## What changed
- Scoped workbench-level waveform shortcuts so they are only enabled on the waveform alignment page.
- Kept host `Ctrl+S` active on the embedded SUG timing page and routed it to `trigger_save()`.
- Added focused tests for embedded SUG shortcut ownership and save forwarding.

## Why
The workbench host shortcuts were consuming keys before the embedded SUG module could handle them. That prevented `Ctrl+S` from saving the SUG project and prevented the SUG shortcut editor from binding `Space`, including long-press Space.

## Validation
- `python -m pytest tests\test_sug_embedded_shortcuts.py tests\test_workbench_updater.py tests\test_ffmpeg_paths.py -q`
