### PR TITLE
fix: preserve embedded SUG settings

### DIFF
--- a/krok_helper/gui_qt.py
+++ b/krok_helper/gui_qt.py
@@ -183,24 +183,55 @@ class KrokHelperSettingsBridge:
         self._save_callback = save_callback
 
     def load(self) -> dict:
+        latest = load_app_settings()
+        self._app_settings.lyrics_timing = deepcopy(latest.lyrics_timing)
         return deepcopy(self._app_settings.lyrics_timing)
 
     def save(self, data: dict) -> None:
-        self._app_settings.lyrics_timing = deepcopy(data)
-        self._save_callback()
+        latest = load_app_settings()
+        latest.lyrics_timing = deepcopy(data)
+        save_app_settings(latest)
+        self._app_settings.lyrics_timing = deepcopy(latest.lyrics_timing)
+
+    def save_partial(self, changes: dict[str, object]) -> None:
+        latest = load_app_settings()
+        config = deepcopy(latest.lyrics_timing)
+        for path, value in changes.items():
+            self._set_nested(config, path, value)
+        latest.lyrics_timing = config
+        save_app_settings(latest)
+        self._app_settings.lyrics_timing = deepcopy(config)
 
     def load_extra(self, key: str, default):
         field_name = self._EXTRA_FIELDS.get(key)
         if field_name is None:
             return deepcopy(default)
+        latest = load_app_settings()
+        setattr(self._app_settings, field_name, deepcopy(getattr(latest, field_name, default)))
         return deepcopy(getattr(self._app_settings, field_name, default))
 
     def save_extra(self, key: str, data) -> None:
         field_name = self._EXTRA_FIELDS.get(key)
         if field_name is None:
             return
+        latest = load_app_settings()
+        setattr(latest, field_name, deepcopy(data))
+        save_app_settings(latest)
         setattr(self._app_settings, field_name, deepcopy(data))
-        self._save_callback()
+
+    @staticmethod
+    def _set_nested(target: dict, path: str, value: object) -> None:
+        cursor = target
+        keys = [key for key in str(path).split(".") if key]
+        if not keys:
+            return
+        for key in keys[:-1]:
+            child = cursor.get(key)
+            if not isinstance(child, dict):
+                child = {}
+                cursor[key] = child
+            cursor = child
+        cursor[keys[-1]] = deepcopy(value)
 
 
 LYRICS_LANGUAGE_OPTIONS = [

--- a/krok_helper/lyrics_timing/src/strange_uta_game/frontend/settings/__init__.py
+++ b/krok_helper/lyrics_timing/src/strange_uta_game/frontend/settings/__init__.py
@@ -3,10 +3,15 @@
 提供应用设置管理界面。
 """
 
-from .settings_interface import (
-    SettingsInterface,
-    AppSettings,
-)
+from .app_settings import AppSettings
+
+
+def __getattr__(name: str):
+    if name == "SettingsInterface":
+        from .settings_interface import SettingsInterface
+
+        return SettingsInterface
+    raise AttributeError(name)
 
 __all__ = [
     "SettingsInterface",

--- a/krok_helper/lyrics_timing/src/strange_uta_game/frontend/settings/app_settings.py
+++ b/krok_helper/lyrics_timing/src/strange_uta_game/frontend/settings/app_settings.py
@@ -346,12 +346,13 @@ class AppSettings:
         参数:
             config_path: 显式 config.json 路径（standalone 调试用）。
                 仅在 ``provider`` 为 None 时生效。
-            provider: 设置后端 Protocol 实现。给定时**完全跳过**所有文件
+        provider: 设置后端 Protocol 实现。给定时**完全跳过**所有文件
                 路径初始化 —— 不解析 ``get_config_dir()``、不读写
                 ``config.json``、不做 dictionary 升级、不做独立文件
                 迁移。``self._settings`` 直接从 ``provider.load()`` 获取，
                 后续 ``save()`` 写回 provider。
         """
+        self._dirty_paths: set[str] = set()
         if provider is not None:
             effective_provider = provider
         elif config_path is None:
@@ -601,9 +602,20 @@ class AppSettings:
         """
         if self._provider is not None:
             try:
+                save_partial = getattr(self._provider, "save_partial", None)
+                if self._dirty_paths and callable(save_partial):
+                    save_partial(
+                        {
+                            path: deepcopy(self.get(path))
+                            for path in sorted(self._dirty_paths)
+                        }
+                    )
+                    self._dirty_paths.clear()
+                    return
                 # deepcopy 出去：provider 应能持有完全独立的副本，避免
                 # 后续 AppSettings.set 改写到 provider 内部状态。
                 self._provider.save(deepcopy(self._settings))
+                self._dirty_paths.clear()
             except Exception as e:
                 print(f"保存设置失败 (provider): {e}")
             return
@@ -627,8 +639,10 @@ class AppSettings:
                 loaded = {}
             if isinstance(loaded, dict):
                 self._deep_merge(self._settings, deepcopy(loaded))
+            self._dirty_paths.clear()
             return
         self._settings = self._load_settings()
+        self._dirty_paths.clear()
 
     def get(self, path: str, default=None) -> Any:
         keys = path.split(".")
@@ -648,6 +662,8 @@ class AppSettings:
                 target[key] = {}
             target = target[key]
         target[keys[-1]] = value
+        if self._provider is not None:
+            self._dirty_paths.add(path)
 
     def get_all(self) -> Dict[str, Any]:
         return self._settings.copy()

--- a/tests/test_lyrics_timing_namespaces.py
+++ b/tests/test_lyrics_timing_namespaces.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from krok_helper.settings import (
     AppSettings as HostSettings,
     load_app_settings,
@@ -100,8 +102,85 @@ def test_strange_uta_game_provider_extra_namespaces_round_trip():
             ],
             "source_order": ["custom"],
         }
+        pytest.importorskip("numpy")
         settings.save_network_dictionary(network_doc)
         assert provider.extras["network"]["custom"]["entries"][0]["word"] == "青"
         assert any(source.get("id") == "custom" for source in AppSettings().load_network_dictionary()["sources"])
     finally:
         AppSettings.set_default_provider(None)
+
+
+def test_strange_uta_game_provider_partial_save_preserves_newer_shortcuts():
+    import krok_helper.lyrics_timing  # noqa: F401 - installs bundled src path
+    from strange_uta_game.frontend.settings.app_settings import AppSettings
+
+    class Provider:
+        def __init__(self):
+            self.config = {}
+
+        def load(self):
+            return json.loads(json.dumps(self.config))
+
+        def save(self, data):
+            self.config = json.loads(json.dumps(data))
+
+        def save_partial(self, changes):
+            for path, value in changes.items():
+                self._set_nested(path, value)
+
+        def _set_nested(self, path, value):
+            cursor = self.config
+            keys = path.split(".")
+            for key in keys[:-1]:
+                child = cursor.get(key)
+                if not isinstance(child, dict):
+                    child = {}
+                    cursor[key] = child
+                cursor = child
+            cursor[keys[-1]] = value
+
+        def load_extra(self, key, default):
+            return default
+
+        def save_extra(self, key, data):
+            _ = key, data
+
+    provider = Provider()
+    AppSettings.set_default_provider(provider)
+    try:
+        stale_settings = AppSettings()
+
+        fresh_settings = AppSettings()
+        fresh_settings.set("shortcuts.timing_mode.tag_now", "SPACE:short")
+        fresh_settings.save()
+
+        stale_settings.set("export.last_export_dir", "D:/lyrics")
+        stale_settings.save()
+
+        reloaded = AppSettings()
+        assert reloaded.get("shortcuts.timing_mode.tag_now") == "SPACE:short"
+        assert reloaded.get("export.last_export_dir") == "D:/lyrics"
+    finally:
+        AppSettings.set_default_provider(None)
+
+
+def test_krok_helper_settings_bridge_partial_save_merges_lyrics_timing(monkeypatch, tmp_path):
+    from krok_helper.gui_qt import KrokHelperSettingsBridge
+
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+    saved = HostSettings(
+        lyrics_timing={
+            "shortcuts": {"timing_mode": {"tag_now": "SPACE:short"}},
+        }
+    )
+    save_app_settings(saved)
+
+    in_memory = HostSettings(lyrics_timing={})
+    bridge = KrokHelperSettingsBridge(in_memory, lambda: save_app_settings(in_memory))
+
+    bridge.save_partial({"export.last_export_dir": "D:/lyrics"})
+
+    loaded = load_app_settings()
+    assert loaded.lyrics_timing["shortcuts"]["timing_mode"]["tag_now"] == "SPACE:short"
+    assert loaded.lyrics_timing["export"]["last_export_dir"] == "D:/lyrics"
+    assert in_memory.lyrics_timing == loaded.lyrics_timing


### PR DESCRIPTION
﻿## What changed
- Added dirty-path tracking for embedded SUG `AppSettings` so provider-backed saves can persist only the keys that changed.
- Added `save_partial()` support to the workbench settings bridge and merge partial SUG updates into the latest `%APPDATA%` workbench settings.
- Kept `strange_uta_game.frontend.settings.AppSettings` import lightweight so settings data access does not pull the full settings UI dependency tree.
- Added regression coverage for stale embedded settings instances preserving newer shortcut bindings.

## Why
In embedded mode, multiple SUG `AppSettings()` instances can exist at the same time. A stale instance that only changes one field could previously save its whole default/old settings snapshot back through the workbench provider, overwriting newer shortcut settings and making them appear reset after reopening the workbench.

## Validation
- `python -m compileall krok_helper\gui_qt.py krok_helper\lyrics_timing\src\strange_uta_game\frontend\settings\app_settings.py krok_helper\lyrics_timing\src\strange_uta_game\frontend\settings\__init__.py tests\test_lyrics_timing_namespaces.py`
- `python -m pytest tests\test_sug_embedded_shortcuts.py tests\test_import_lyrics_to_sug.py tests\test_lyrics_timing_namespaces.py -q`

The pytest run reported `9 passed, 2 skipped`; skipped cases require the local SUG `numpy` dependency.
