### PR TITLE
Add embedded SUG crash recovery prompt

### DIFF
--- a/krok_helper/gui_qt.py
+++ b/krok_helper/gui_qt.py
@@ -1919,6 +1919,7 @@ class KrokHelperQtApp(QMainWindow):
         self.preview_timer = QTimer(self)
         self.preview_timer.setInterval(300)
         self.preview_timer.timeout.connect(self._poll_alignment_preview)
+        QTimer.singleShot(800, self._check_lyrics_timing_crash_recovery)
         QTimer.singleShot(2500, self._check_for_workbench_update_on_startup)
 
     def _track_background_task(self, attr_name: str, task: BackgroundTask) -> BackgroundTask:
@@ -5139,6 +5140,30 @@ class KrokHelperQtApp(QMainWindow):
         self.ffmpeg_dir_text = str(path) if str(path).strip() else ""
         self._sync_ffmpeg_labels()
         self._sync_lyrics_timing_host_paths()
+
+    def _check_lyrics_timing_crash_recovery(self) -> None:
+        """启动时让嵌入的歌词打轴模块检查闪退恢复文件。
+
+        若发现待恢复的临时文件，先切到歌词打轴模块（让用户看到上下文），
+        再弹出"是否恢复"对话框。用户拒绝时停留在该模块，由用户自行返回。
+        """
+        page = getattr(self, "lyrics_timing_page", None)
+        if page is None or not hasattr(page, "check_crash_recovery"):
+            return
+        try:
+            has_pending = bool(
+                hasattr(page, "has_pending_crash_recovery")
+                and page.has_pending_crash_recovery()
+            )
+        except Exception:
+            return
+        if not has_pending:
+            return
+        self._show_module(WORKFLOW_LYRICS_TIMING)
+        try:
+            page.check_crash_recovery(dialog_parent=self)
+        except Exception:
+            pass
 
     def _sync_lyrics_timing_host_paths(self) -> None:
         """Inject host-managed runtime paths into the embedded timing module."""

--- a/krok_helper/lyrics_timing/src/strange_uta_game/frontend/main_window.py
+++ b/krok_helper/lyrics_timing/src/strange_uta_game/frontend/main_window.py
@@ -121,7 +121,7 @@ class MainWindow(MSFluentWindow):
         #   宿主显式调度（保持本模块"嵌入后零启动副作用"）。
         if not self._embedded:
             # 延迟检查闪退恢复（等 UI 显示完毕后再弹窗）
-            QTimer.singleShot(500, self._check_crash_recovery)
+            QTimer.singleShot(500, self.check_crash_recovery)
             # 延迟检查应用自动更新（在闪退恢复之后，避免抢占用户注意力）。
             # 失败/无网时静默跳过，绝不阻塞主流程。
             QTimer.singleShot(2500, self._check_for_app_update)
@@ -622,12 +622,27 @@ class MainWindow(MSFluentWindow):
 
     # ==================== 闪退恢复 ====================
 
-    def _check_crash_recovery(self):
-        """启动时检查是否有未命名项目的闪退恢复文件。"""
-        if not ProjectStore.has_crash_recovery():
-            return
+    @staticmethod
+    def has_pending_crash_recovery() -> bool:
+        """是否存在待恢复的闪退临时文件（公开 API，供宿主在弹窗前查询）。"""
+        return ProjectStore.has_crash_recovery()
 
-        msg = QMessageBox(self)
+    def check_crash_recovery(self, dialog_parent: "Optional[object]" = None) -> bool:
+        """检查是否有闪退恢复文件，并询问用户是否加载。
+
+        standalone 模式由 :meth:`__init__` 启动期定时器自动触发，embedded 模式
+        由宿主在窗口显示后显式调用，并传入自己的顶层窗口作为弹窗 parent，
+        避免 QMessageBox 出现在尚未可见的子 widget 上。
+
+        Returns:
+            True 表示用户选择恢复且成功加载了项目；其余情况均为 False
+            （包括没有恢复文件、用户拒绝、加载失败）。
+        """
+        if not ProjectStore.has_crash_recovery():
+            return False
+
+        parent = dialog_parent if dialog_parent is not None else self
+        msg = QMessageBox(parent)
         msg.setWindowTitle("恢复未保存的项目")
         msg.setText("检测到上次异常退出时的未保存项目数据。\n是否加载恢复？")
         btn_yes = msg.addButton("是", QMessageBox.ButtonRole.AcceptRole)
@@ -651,6 +666,7 @@ class MainWindow(MSFluentWindow):
                 )
                 # 恢复后删除临时文件
                 ProjectStore.delete_crash_recovery()
+                return True
             else:
                 InfoBar.error(
                     title="恢复失败",
@@ -662,9 +678,11 @@ class MainWindow(MSFluentWindow):
                     parent=self,
                 )
                 ProjectStore.delete_crash_recovery()
+                return False
         else:
             # 用户拒绝恢复 → 删除临时文件
             ProjectStore.delete_crash_recovery()
+            return False
 
     # ==================== 自动更新检查 ====================
 


### PR DESCRIPTION
## Summary
- 嵌入模式下 SUG 的周期保存一直在写 `.sug.temp`，但工作台从未调用 SUG 的"闪退恢复"检测，下次启动看不到恢复弹窗。
- 把 SUG 的 `_check_crash_recovery` 改成公开方法 `check_crash_recovery(dialog_parent=None) -> bool`，并新增静态查询 `has_pending_crash_recovery()`，让宿主能在不触发弹窗的前提下提前判定。
- 宿主 `KrokHelperQtApp` 启动 800ms 后查询；若发现待恢复文件，先 `_show_module(WORKFLOW_LYRICS_TIMING)` 切到歌词打轴模块作为上下文，再让 SUG 弹出"是否恢复"对话框（对话框 parent 设成宿主顶层窗口，避免出现在尚未可见的子 widget 上）。

## Test plan
- [x] `pytest tests/test_sug_embedded_shortcuts.py`
- [ ] 工作台 → 歌词打轴 → 编辑产生未保存改动 → 直接关闭窗口（宿主 closeEvent 自动 `flush_unsaved`）→ 重启工作台 → 自动切到歌词打轴模块并弹出恢复弹窗
- [ ] 弹窗点"是" → 项目恢复，temp 文件被删除
- [ ] 弹窗点"否" → temp 文件被删除，停留在歌词打轴模块
- [ ] 没有 temp 文件时启动 → 无任何弹窗、无模块切换，停留在默认模块

🤖 Generated with [Claude Code](https://claude.com/claude-code)