### PR TITLE
fix(lyrics_timing): force build to use local src and fail fast on sta…

### DIFF
--- a/krok_helper/lyrics_timing/CHANGELOG.md
+++ b/krok_helper/lyrics_timing/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### 修复项目
 - 从预设加载演唱者时，若项目仅有占位默认演唱者，其名下歌词会被级联删除
 - 设置 cascade 加防御性兜底：`_apply_settings` 与全局偏移更新中的 Python 异常不再透传到 Qt 派发层，避免出现 0xC0000409 原生闪退
+- `build.py` 强制把本地 `src/` 顶到 `sys.path` 最前，避免环境里旧位置的 `pip install -e .`（如 `E:\KaraMaker\StrangeUtaGame\`）让 PyInstaller 把旧 bytecode 打进 PYZ 导致打包后修复失效，同时打印实际命中的 `strange_uta_game` 路径便于自检
 
 
 ## [1.1.1] - 2026-06-04

--- a/krok_helper/lyrics_timing/build.py
+++ b/krok_helper/lyrics_timing/build.py
@@ -51,6 +51,40 @@ VARIANT = _cli_args.variant
 PROJECT_ROOT = Path(__file__).parent.absolute()
 VERSION_FILE = PROJECT_ROOT / "src" / "strange_uta_game" / "__version__.py"
 
+# ── 防呆：让本地 src/ 屏蔽任何旧的 editable install ──────────────────────────
+# 历史上 strange_uta_game 曾以独立仓库 E:\KaraMaker\StrangeUtaGame\ 形式存在并
+# 被 `pip install -e .`，迁移到 krok_helper/lyrics_timing 之后那份 editable
+# install 仍会留在 Python 环境的 sys.path 里。PyInstaller 做 import 分析时
+# 命中的就是旧路径，最终 PYZ 里打进去的是旧 bytecode；--add-data 复制进
+# dist/_internal/strange_uta_game/ 的新源码只是陪跑，运行时不会被加载，
+# 表现就是"源码改了、dist 里也有新文件，可装好的 EXE 行为却照旧"。
+#
+# 把本地 src 放到 sys.path 最前并打印实际命中路径，让每次打包都能在控制台
+# 立刻看出"这次打的是哪份 strange_uta_game"。
+_SRC_DIR = str(PROJECT_ROOT / "src")
+while _SRC_DIR in sys.path:
+    sys.path.remove(_SRC_DIR)
+sys.path.insert(0, _SRC_DIR)
+try:
+    import strange_uta_game as _sug_probe
+
+    _sug_path = Path(_sug_probe.__file__).resolve()
+    _expected = (PROJECT_ROOT / "src" / "strange_uta_game" / "__init__.py").resolve()
+    if _sug_path != _expected:
+        raise SystemExit(
+            "✗ 打包前自检失败：import strange_uta_game 命中的不是本仓库源码。\n"
+            f"  期望: {_expected}\n"
+            f"  实际: {_sug_path}\n"
+            "  常见原因：环境里有旧位置的 `pip install -e .`（例如\n"
+            "  E:\\KaraMaker\\StrangeUtaGame\\）。先 `pip uninstall strange-uta-game`\n"
+            "  或确认 sys.path 头部为当前 src/ 后重试。"
+        )
+    print(f"✓ 打包将使用: {_sug_path}")
+    del _sug_probe
+except ImportError:
+    # 还没装/没找到都没关系，sys.path 已经放进去了，PyInstaller 自己也能找到
+    print(f"  (尚未 import strange_uta_game，将走 sys.path 首项: {_SRC_DIR})")
+
 # ── 变体配置 ──────────────────────────────────────────────────────────────────
 
 # 每个变体的 PyInstaller 额外参数（在公共参数基础上叠加）


### PR DESCRIPTION
## Summary
打包后修复失效的根因：环境里残留旧位置 `E:\KaraMaker\StrangeUtaGame\` 的 `pip install -e .`，PyInstaller import 分析命中旧路径，把旧 bytecode 打进 PYZ；`--add-data` 复制进 `dist/_internal/strange_uta_game/` 的新源码只是陪跑，运行时不会被加载。表现就是"源码改了、dist 里也有新文件，可装好的 EXE 行为照旧"——演唱者预设那个修复打包后失效就是中招样本。

- `build.py` 在 `PROJECT_ROOT` 定义之后强制把本地 `src/` 顶到 `sys.path` 最前
- 自检 `import strange_uta_game` 的实际命中路径，不是本仓库就立即 `SystemExit`
- 每次打包都打印实际命中的 `strange_uta_game.__file__`，下次环境再被污染能即刻看出
- 用户保留旧仓库的 `pip install -e .` 不再影响新仓库打包