### PR TITLE
[codex] Fix workbench updater proxy and branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Karaoke Helper（卡拉OK工作台）
+# Karaoke Studio（卡拉OK工作台）
 
 当前版本：`3.0.0`
 
-`Karaoke Helper` 是一个面向卡拉 OK / B 站投稿制作流程的 Windows 桌面工具。
+`Karaoke Studio` 是一个面向卡拉 OK / B 站投稿制作流程的 Windows 桌面工具。
 界面以一条「6 步工作流」串联整个制作链路，目前已经实现 4 个功能模块，另外 2 个为占位（规划中）。
 
 已实现模块：
@@ -309,7 +309,7 @@ python -m krok_helper `
 Windows 默认保存在：
 
 ```text
-%APPDATA%\Karaoke Helper\settings.json
+%APPDATA%\Karaoke Studio\settings.json
 ```
 
 当前会保存：
@@ -323,7 +323,7 @@ Windows 默认保存在：
 Bilibili 登录 Cookie 默认保存在：
 
 ```text
-%APPDATA%\Karaoke Helper\video_download\bilibili_cookies.txt
+%APPDATA%\Karaoke Studio\video_download\bilibili_cookies.txt
 ```
 
 ## 打包
@@ -339,13 +339,13 @@ Bilibili 登录 Cookie 默认保存在：
 输出目录：
 
 ```text
-dist\windows\Karaoke Helper\
+dist\windows\Karaoke Studio\
 ```
 
 主程序：
 
 ```text
-dist\windows\Karaoke Helper\Karaoke Helper.exe
+dist\windows\Karaoke Studio\Karaoke Studio.exe
 ```
 
 ### macOS
@@ -365,7 +365,7 @@ chmod +x ./scripts/build_macos.command
 输出目录：
 
 ```text
-dist/macos/Karaoke Helper.app
+dist/macos/Karaoke Studio.app
 ```
 
 > 注意：当前打包脚本安装并裁剪的是 `PySide6`，而源码实际依赖 `PyQt6` + `PyQt6-Fluent-Widgets`，两者并不一致，打包前请先核对（见下文「已知问题」）。

--- a/krok_helper/__init__.py
+++ b/krok_helper/__init__.py
@@ -1,1 +1,1 @@
-"""Karaoke Helper package."""
+"""Karaoke Studio package."""

--- a/krok_helper/cli.py
+++ b/krok_helper/cli.py
@@ -78,7 +78,7 @@ def run_cli(args: argparse.Namespace) -> int:
 
 def run_gui(args: argparse.Namespace) -> int:
     enable_high_dpi_awareness()
-    set_explicit_app_user_model_id("KaraokeHelper.Desktop")
+    set_explicit_app_user_model_id("KaraokeStudio.Desktop")
     qt_app = QApplication.instance() or QApplication(sys.argv)
     # 在 ``MainWindow()`` 构造**之前**就把主题 settle 到目标模式 ——
     # 这样窗口首次绘制即正确颜色，避免"浅色闪一帧"。

--- a/krok_helper/config.py
+++ b/krok_helper/config.py
@@ -1,4 +1,4 @@
-APP_NAME = "Karaoke Helper"
+APP_NAME = "Karaoke Studio"
 APP_VERSION = "3.0.0"
 APP_TITLE = "卡拉OK工作台"
 MIN_HIRES_SAMPLE_RATE = 48_000

--- a/krok_helper/gui_qt.py
+++ b/krok_helper/gui_qt.py
@@ -5601,8 +5601,7 @@ class KrokHelperQtApp(QMainWindow):
 
         def resolve_proxy_status() -> tuple[str, dict[str, str] | None]:
             try:
-                import krok_helper.lyrics_timing  # noqa: F401 - installs bundled src path
-                from strange_uta_game.updater.proxy import resolve_proxy
+                from krok_helper.network import resolve_proxy
 
                 info, proxies = resolve_proxy(current_proxy_mode(), proxy_manual_edit.text().strip())
                 if info is not None and info.is_valid:
@@ -5634,12 +5633,17 @@ class KrokHelperQtApp(QMainWindow):
             QApplication.processEvents()
             _text, proxies = resolve_proxy_status()
             try:
-                import requests
+                from krok_helper.network import requests_session_for_proxy
 
-                response = requests.get(
+                session, resolved_proxies = requests_session_for_proxy(
+                    current_proxy_mode(),
+                    proxy_manual_edit.text().strip(),
+                )
+
+                response = session.get(
                     "https://api.github.com/repos/karaoke-studio/karaoke-studio/releases/latest",
-                    headers={"User-Agent": "KaraokeHelper-Updater/1.0"},
-                    proxies=proxies,
+                    headers={"User-Agent": "KaraokeStudio-Updater/1.0"},
+                    proxies=resolved_proxies if resolved_proxies is not None else proxies,
                     timeout=(5, 15),
                 )
                 if response.status_code == 200:
@@ -6043,8 +6047,7 @@ class KrokHelperQtApp(QMainWindow):
             QMessageBox.critical(self, APP_TITLE, "缺少更新下载信息，请到 GitHub Release 手动下载。")
             return
         try:
-            import krok_helper.lyrics_timing  # noqa: F401 - installs bundled src path
-            from strange_uta_game.updater import installer
+            from krok_helper.updater import installer
         except Exception as exc:  # noqa: BLE001
             QMessageBox.critical(self, APP_TITLE, f"无法加载更新器：\n{exc}")
             return
@@ -6052,11 +6055,10 @@ class KrokHelperQtApp(QMainWindow):
             QMessageBox.information(self, APP_TITLE, "缺少 Updater.exe。请到 GitHub Release 手动下载最新版本。")
             return
         proxy_settings = UpdaterSettings.load(self.settings)
-        proxy_url = ""
-        if proxy_settings.proxy_mode == "manual" and proxy_settings.proxy_manual_url.strip():
-            proxy_url = proxy_settings.proxy_manual_url.strip()
-            if "://" not in proxy_url:
-                proxy_url = f"http://{proxy_url}"
+        from krok_helper.network import resolve_proxy
+
+        info, _proxies = resolve_proxy(proxy_settings.proxy_mode, proxy_settings.proxy_manual_url)
+        proxy_url = info.url if info is not None and info.is_valid else ""
         plan = installer.LaunchPlan(
             app_dir=installer.find_app_dir(),
             app_exe_name=installer.find_app_exe_name(),
@@ -7142,7 +7144,7 @@ class KrokHelperQtApp(QMainWindow):
 
 
 def launch_qt_app() -> int:
-    set_explicit_app_user_model_id("KaraokeHelper.Desktop")
+    set_explicit_app_user_model_id("KaraokeStudio.Desktop")
     sync_fluent_ui_fonts()
     app = QApplication.instance() or QApplication([])
     app.setFont(build_app_ui_font())

--- a/krok_helper/lyrics.py
+++ b/krok_helper/lyrics.py
@@ -1214,7 +1214,13 @@ def _page_count(limit: int, page_size: int) -> int:
 
 def _load_json_from_request(request: Request) -> dict | list:
     try:
-        with urlopen(request, timeout=20) as response:
+        try:
+            from krok_helper.network import build_urllib_opener_for_current_settings
+
+            open_request = build_urllib_opener_for_current_settings().open
+        except Exception:
+            open_request = urlopen
+        with open_request(request, timeout=20) as response:
             payload = response.read()
             content_encoding = response.headers.get("Content-Encoding", "")
     except HTTPError as exc:

--- a/krok_helper/lyrics_timing/updater_app/main.py
+++ b/krok_helper/lyrics_timing/updater_app/main.py
@@ -72,6 +72,7 @@ LOG_FORMAT = "[%(asctime)s] %(levelname)s %(message)s"
 DATE_FORMAT = "%H:%M:%S"
 
 TMP_DIR_NAME = "StrangeUtaGameUpdater"
+PRODUCT_NAME = "StrangeUtaGame"
 CHUNK_SIZE = 128 * 1024
 DEFAULT_USER_AGENT = "StrangeUtaGame-Updater/standalone"
 
@@ -116,8 +117,8 @@ class Args:
 
 def parse_args(argv: Optional[List[str]] = None) -> Args:
     p = argparse.ArgumentParser(
-        prog="StrangeUtaGame Updater",
-        description="替换 StrangeUtaGame.exe 与 _internal/ 下的文件，并重启应用。",
+        prog=f"{PRODUCT_NAME} Updater",
+        description=f"替换 {PRODUCT_NAME}.exe 与 _internal/ 下的文件，并重启应用。",
     )
     p.add_argument("--app-dir", required=True, type=Path)
     p.add_argument("--app-exe", required=True, type=str)
@@ -1141,7 +1142,7 @@ def run(args: Args) -> int:
 
     log = setup_logger(work_dir / "updater.log")
     log.info("=" * 60)
-    log.info("StrangeUtaGame Updater 启动")
+    log.info("%s Updater 启动", PRODUCT_NAME)
     log.info("目标版本: v%s  (tag: %s)", args.target_version, args.target_tag)
     log.info("主程序目录: %s", args.app_dir)
     log.info("主程序 EXE: %s", args.app_exe)

--- a/krok_helper/network.py
+++ b/krok_helper/network.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import urllib.request
+from dataclasses import dataclass
+from typing import Any
+
+
+COMMON_PROXY_PORTS: tuple[int, ...] = (
+    7890,
+    7891,
+    7897,
+    17897,
+    10809,
+    10808,
+    1080,
+    1081,
+    2080,
+    8118,
+    8888,
+    8889,
+    20171,
+    20172,
+    33210,
+    7070,
+    6152,
+    1087,
+)
+
+PROXY_ENV_KEYS: tuple[str, ...] = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+)
+
+
+@dataclass(frozen=True)
+class ProxyInfo:
+    url: str
+    source: str = ""
+
+    @property
+    def is_valid(self) -> bool:
+        return bool(self.url)
+
+
+def _parse_proxy_server(raw: str) -> str:
+    value = (raw or "").strip()
+    if not value:
+        return ""
+    if "=" in value:
+        parts = [part.strip() for part in value.split(";") if part.strip()]
+        mapping: dict[str, str] = {}
+        for part in parts:
+            if "=" not in part:
+                continue
+            key, item = part.split("=", 1)
+            mapping[key.strip().lower()] = item.strip()
+        value = mapping.get("https") or mapping.get("http") or ""
+    if value and "://" not in value:
+        value = f"http://{value}"
+    return value
+
+
+def read_system_proxy() -> ProxyInfo | None:
+    if sys.platform != "win32":
+        return None
+    try:
+        import winreg  # type: ignore[import-not-found]
+
+        key_path = r"Software\Microsoft\Windows\CurrentVersion\Internet Settings"
+        with winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_path) as key:
+            try:
+                enabled, _ = winreg.QueryValueEx(key, "ProxyEnable")
+            except FileNotFoundError:
+                return None
+            if not int(enabled):
+                return None
+            try:
+                server, _ = winreg.QueryValueEx(key, "ProxyServer")
+            except FileNotFoundError:
+                return None
+    except Exception:
+        return None
+
+    url = _parse_proxy_server(str(server))
+    return ProxyInfo(url=url, source="system") if url else None
+
+
+def _is_port_open(host: str, port: int, timeout: float = 0.15) -> bool:
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(timeout)
+            sock.connect((host, port))
+        return True
+    except OSError:
+        return False
+
+
+def scan_local_proxy_ports(
+    ports: tuple[int, ...] = COMMON_PROXY_PORTS,
+    timeout: float = 0.15,
+) -> list[int]:
+    return [port for port in ports if _is_port_open("127.0.0.1", port, timeout=timeout)]
+
+
+def detect_proxy_auto(extra_ports: tuple[int, ...] | None = None) -> ProxyInfo | None:
+    system_proxy = read_system_proxy()
+    if system_proxy and system_proxy.is_valid:
+        return system_proxy
+
+    ports = COMMON_PROXY_PORTS
+    if extra_ports:
+        ports = tuple(dict.fromkeys((*COMMON_PROXY_PORTS, *extra_ports)))
+    found = scan_local_proxy_ports(ports)
+    if not found:
+        return None
+    return ProxyInfo(url=f"http://127.0.0.1:{found[0]}", source="scan")
+
+
+def parse_manual_proxy(value: str) -> ProxyInfo | None:
+    url = (value or "").strip()
+    if not url:
+        return None
+    if "://" not in url:
+        url = f"http://{url}"
+    host_part = url.rsplit("@", 1)[-1].split("://", 1)[-1]
+    if ":" not in host_part:
+        return None
+    return ProxyInfo(url=url, source="manual")
+
+
+def resolve_proxy(mode: str, manual_value: str = "") -> tuple[ProxyInfo | None, dict[str, str] | None]:
+    if mode == "system":
+        info = read_system_proxy()
+    elif mode == "manual":
+        info = parse_manual_proxy(manual_value)
+    elif mode == "auto":
+        info = detect_proxy_auto()
+    else:
+        info = None
+
+    if not info or not info.is_valid:
+        return None, None
+    return info, {"http": info.url, "https": info.url}
+
+
+def _updater_settings_from_app_settings(app_settings: Any):
+    from krok_helper.updater.settings import UpdaterSettings
+
+    return UpdaterSettings.load(app_settings)
+
+
+def resolve_app_proxy(app_settings: Any) -> tuple[ProxyInfo | None, dict[str, str] | None]:
+    settings = _updater_settings_from_app_settings(app_settings)
+    return resolve_proxy(settings.proxy_mode, settings.proxy_manual_url)
+
+
+def proxy_url_for_app_settings(app_settings: Any) -> str:
+    info, _proxies = resolve_app_proxy(app_settings)
+    return info.url if info and info.is_valid else ""
+
+
+def requests_session_for_proxy(mode: str, manual_value: str = ""):
+    import requests
+
+    session = requests.Session()
+    info, proxies = resolve_proxy(mode, manual_value)
+    if mode == "off" or proxies:
+        session.trust_env = False
+    return session, proxies
+
+
+def requests_session_for_app_settings(app_settings: Any):
+    settings = _updater_settings_from_app_settings(app_settings)
+    return requests_session_for_proxy(settings.proxy_mode, settings.proxy_manual_url)
+
+
+def urllib_proxy_handler_for_app_settings(app_settings: Any) -> urllib.request.ProxyHandler | None:
+    settings = _updater_settings_from_app_settings(app_settings)
+    info, _proxies = resolve_proxy(settings.proxy_mode, settings.proxy_manual_url)
+    if info and info.is_valid:
+        return urllib.request.ProxyHandler({"http": info.url, "https": info.url})
+    if settings.proxy_mode == "off":
+        return urllib.request.ProxyHandler({})
+    return None
+
+
+def build_urllib_opener_for_app_settings(app_settings: Any, *handlers):
+    proxy_handler = urllib_proxy_handler_for_app_settings(app_settings)
+    if proxy_handler is not None:
+        return urllib.request.build_opener(proxy_handler, *handlers)
+    if handlers:
+        return urllib.request.build_opener(*handlers)
+    return urllib.request.build_opener()
+
+
+def load_current_app_settings():
+    from krok_helper.settings import load_app_settings
+
+    return load_app_settings()
+
+
+def build_urllib_opener_for_current_settings(*handlers):
+    return build_urllib_opener_for_app_settings(load_current_app_settings(), *handlers)
+
+
+def subprocess_env_for_app_settings(app_settings: Any) -> dict[str, str]:
+    env = os.environ.copy()
+    settings = _updater_settings_from_app_settings(app_settings)
+    url = proxy_url_for_app_settings(app_settings)
+    if url:
+        env["HTTP_PROXY"] = url
+        env["HTTPS_PROXY"] = url
+        env["ALL_PROXY"] = url
+        env["http_proxy"] = url
+        env["https_proxy"] = url
+        env["all_proxy"] = url
+    elif settings.proxy_mode == "off":
+        for key in PROXY_ENV_KEYS:
+            env.pop(key, None)
+    return env
+
+
+def subprocess_env_for_current_settings() -> dict[str, str]:
+    return subprocess_env_for_app_settings(load_current_app_settings())
+
+
+def subprocess_kwargs_for_app_settings(app_settings: Any) -> dict[str, Any]:
+    return {"env": subprocess_env_for_app_settings(app_settings)}
+
+
+def proxy_cli_args_for_app_settings(app_settings: Any) -> list[str]:
+    url = proxy_url_for_app_settings(app_settings)
+    return ["--proxy", url] if url else []
+

--- a/krok_helper/settings.py
+++ b/krok_helper/settings.py
@@ -21,6 +21,7 @@ from krok_helper.video_download.download_task import NAMING_RULE_TITLE, SOURCE_Y
 SETTINGS_FILE_NAME = "settings.json"
 ALIGN_TARGET_VIDEO = "video"
 ALIGN_TARGET_AUDIO = "audio"
+LEGACY_APP_NAMES = ("Karaoke Helper",)
 
 # 工作台界面主题：跟随系统 / 强制浅色 / 强制深色。
 # 与 SUG ``frontend/theme.py::ThemeMode`` 对应。新值必须同步两边。
@@ -82,20 +83,30 @@ class AppSettings:
     lyrics_timing_migrated_v1: bool = False
 
 
-def get_settings_path() -> Path:
+def _settings_path_for_app_name(app_name: str) -> Path:
     appdata = os.getenv("APPDATA")
     if os.name == "nt" and appdata:
-        return Path(appdata) / APP_NAME / SETTINGS_FILE_NAME
+        return Path(appdata) / app_name / SETTINGS_FILE_NAME
 
     config_home = os.getenv("XDG_CONFIG_HOME")
     if config_home:
-        return Path(config_home) / APP_NAME.lower().replace(" ", "-") / SETTINGS_FILE_NAME
+        return Path(config_home) / app_name.lower().replace(" ", "-") / SETTINGS_FILE_NAME
 
-    return Path.home() / ".config" / APP_NAME.lower().replace(" ", "-") / SETTINGS_FILE_NAME
+    return Path.home() / ".config" / app_name.lower().replace(" ", "-") / SETTINGS_FILE_NAME
+
+
+def get_settings_path() -> Path:
+    return _settings_path_for_app_name(APP_NAME)
+
+
+def get_legacy_settings_paths() -> list[Path]:
+    return [_settings_path_for_app_name(name) for name in LEGACY_APP_NAMES]
 
 
 def load_app_settings() -> AppSettings:
     path = get_settings_path()
+    if not path.is_file():
+        path = next((legacy for legacy in get_legacy_settings_paths() if legacy.is_file()), path)
     if not path.is_file():
         return AppSettings()
 

--- a/krok_helper/updater/installer.py
+++ b/krok_helper/updater/installer.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+UPDATER_EXE_NAME = "Updater.exe"
+TMP_DIR_NAME = "KaraokeStudioUpdater"
+DEFAULT_APP_EXE_NAME = "Karaoke Studio.exe"
+
+
+@dataclass
+class LaunchPlan:
+    app_dir: Path
+    app_exe_name: str
+    target_version: str
+    target_tag: str
+    asset_name: str
+    download_urls: list[tuple[str, str]]
+    proxy_url: str = ""
+    internal_dir_name: str = "_internal"
+    expected_sha256: str = ""
+    launch_after_update: bool = True
+    extras: list[str] = field(default_factory=list)
+
+    def command_args(self, updater_exe: Path, current_pid: int) -> list[str]:
+        args = [str(updater_exe)]
+        args += ["--app-dir", str(self.app_dir)]
+        args += ["--app-exe", self.app_exe_name]
+        args += ["--target-version", self.target_version]
+        args += ["--target-tag", self.target_tag]
+        args += ["--asset-name", self.asset_name]
+        args += ["--internal-name", self.internal_dir_name]
+        args += ["--pid", str(current_pid)]
+        if self.proxy_url:
+            args += ["--proxy", self.proxy_url]
+        if self.expected_sha256:
+            args += ["--sha256", self.expected_sha256]
+        if not self.launch_after_update:
+            args += ["--no-launch"]
+        for source_id, url in self.download_urls:
+            args += ["--url", f"{source_id}|{url}"]
+        args += self.extras
+        return args
+
+
+@dataclass
+class LaunchResult:
+    launched: bool
+    updater_path: str = ""
+    temp_copy_path: str = ""
+    pid: int = 0
+    reason: str = ""
+
+
+def find_app_dir() -> Path:
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).resolve().parent
+    return Path(sys.argv[0]).resolve().parent
+
+
+def find_app_exe_name() -> str:
+    if getattr(sys, "frozen", False):
+        return Path(sys.executable).name
+    return DEFAULT_APP_EXE_NAME
+
+
+def find_updater_exe(app_dir: Optional[Path] = None) -> Optional[Path]:
+    root = app_dir or find_app_dir()
+    for path in (
+        root / UPDATER_EXE_NAME,
+        root / "_internal" / "updater" / UPDATER_EXE_NAME,
+    ):
+        if path.exists():
+            return path
+    return None
+
+
+def is_updater_available(app_dir: Optional[Path] = None) -> bool:
+    return find_updater_exe(app_dir) is not None
+
+
+def _copy_updater_to_temp(updater_exe: Path) -> Path:
+    tmp_dir = Path(tempfile.gettempdir()) / TMP_DIR_NAME
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    dest = tmp_dir / UPDATER_EXE_NAME
+    try:
+        shutil.copy2(str(updater_exe), str(dest))
+    except PermissionError:
+        dest = tmp_dir / f"Updater-{int(time.time())}.exe"
+        shutil.copy2(str(updater_exe), str(dest))
+    return dest
+
+
+def launch_updater(plan: LaunchPlan) -> LaunchResult:
+    updater = find_updater_exe(plan.app_dir)
+    if updater is None:
+        return LaunchResult(
+            launched=False,
+            reason="Updater.exe was not found next to the application.",
+        )
+    try:
+        temp_copy = _copy_updater_to_temp(updater)
+    except Exception as exc:  # noqa: BLE001
+        return LaunchResult(launched=False, reason=f"Failed to copy Updater.exe: {exc}")
+
+    args = plan.command_args(temp_copy, os.getpid())
+    try:
+        proc = subprocess.Popen(
+            args,
+            cwd=str(plan.app_dir),
+            close_fds=True,
+            creationflags=getattr(subprocess, "CREATE_NEW_CONSOLE", 0),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return LaunchResult(launched=False, updater_path=str(updater), temp_copy_path=str(temp_copy), reason=str(exc))
+
+    return LaunchResult(
+        launched=True,
+        updater_path=str(updater),
+        temp_copy_path=str(temp_copy),
+        pid=int(proc.pid),
+    )
+

--- a/krok_helper/updater/worker.py
+++ b/krok_helper/updater/worker.py
@@ -9,6 +9,7 @@ from typing import Any
 from PyQt6.QtCore import QObject, QThread, pyqtSignal
 
 from krok_helper.config import APP_VERSION
+from krok_helper.network import requests_session_for_proxy
 from krok_helper.updater.settings import UpdaterSettings
 from krok_helper.updater.sources import SourceId, build_api_urls, build_release_urls
 
@@ -90,8 +91,8 @@ def is_newer_version(remote: str, local: str = APP_VERSION) -> bool:
 
 def current_asset_name() -> str:
     if sys.platform == "darwin":
-        return "KaraokeHelper-macos.zip"
-    return "KaraokeHelper-windows.zip"
+        return "KaraokeStudio-macos.zip"
+    return "KaraokeStudio-windows.zip"
 
 
 def _parse_release(payload: dict[str, Any]) -> LatestRelease:
@@ -123,35 +124,20 @@ def _parse_release(payload: dict[str, Any]) -> LatestRelease:
 
 
 def _proxies_for(settings: UpdaterSettings) -> dict[str, str] | None:
-    try:
-        import krok_helper.lyrics_timing  # noqa: F401 - installs bundled src path
-        from strange_uta_game.updater.proxy import resolve_proxy
-
-        _info, proxies = resolve_proxy(settings.proxy_mode, settings.proxy_manual_url)
-        return proxies
-    except Exception:
-        if settings.proxy_mode == "off":
-            return {}
-        if settings.proxy_mode == "manual" and settings.proxy_manual_url.strip():
-            url = settings.proxy_manual_url.strip()
-            if "://" not in url:
-                url = f"http://{url}"
-            return {"http": url, "https": url}
-        return None
+    _session, proxies = requests_session_for_proxy(settings.proxy_mode, settings.proxy_manual_url)
+    return proxies
 
 
 def fetch_latest_release(
     settings: UpdaterSettings,
 ) -> tuple[LatestRelease | None, list[tuple[SourceId, str, str]]]:
     attempts: list[tuple[SourceId, str, str]] = []
-    proxies = _proxies_for(settings)
+    session, proxies = requests_session_for_proxy(settings.proxy_mode, settings.proxy_manual_url)
     for source, url in build_api_urls(settings.source_order):
         try:
-            import requests
-
-            response = requests.get(
+            response = session.get(
                 url,
-                headers={"User-Agent": "KaraokeHelper-Updater/1.0", "Accept": "application/json"},
+                headers={"User-Agent": "KaraokeStudio-Updater/1.0", "Accept": "application/json"},
                 proxies=proxies,
                 timeout=(5, 20),
                 allow_redirects=True,

--- a/krok_helper/updater_app/__init__.py
+++ b/krok_helper/updater_app/__init__.py
@@ -1,0 +1,2 @@
+"""Karaoke Studio standalone updater entry points."""
+

--- a/krok_helper/updater_app/build_updater.py
+++ b/krok_helper/updater_app/build_updater.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parent
+REPO_ROOT = PROJECT_ROOT.parents[1]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Build Karaoke Studio Updater.exe")
+    parser.add_argument("--clean", action="store_true", default=False)
+    args = parser.parse_args()
+
+    try:
+        import PyInstaller.__main__ as pyinstaller
+    except ImportError:
+        print("Missing pyinstaller. Please install it before building Updater.exe.", file=sys.stderr)
+        return 1
+
+    pi_args = [
+        str(PROJECT_ROOT / "main.py"),
+        "--name=Updater",
+        "--onefile",
+        "--console",
+        "--noconfirm",
+        "--distpath",
+        str(PROJECT_ROOT / "dist"),
+        "--workpath",
+        str(PROJECT_ROOT / "build"),
+        "--specpath",
+        str(PROJECT_ROOT),
+        "--paths",
+        str(REPO_ROOT),
+        "--collect-submodules=requests",
+        "--hidden-import=krok_helper.lyrics_timing.updater_app.main",
+        "--hidden-import=requests",
+        "--hidden-import=urllib3",
+        "--hidden-import=charset_normalizer",
+        "--hidden-import=idna",
+        "--hidden-import=certifi",
+        "--hidden-import=colorsys",
+        "--hidden-import=encodings",
+        "--hidden-import=encodings.idna",
+        "--hidden-import=encodings.utf_8",
+        "--hidden-import=encodings.utf_8_sig",
+        "--hidden-import=encodings.cp1252",
+        "--hidden-import=encodings.cp437",
+        "--hidden-import=encodings.cp65001",
+        "--hidden-import=encodings.gbk",
+        "--hidden-import=encodings.mbcs",
+        "--hidden-import=hashlib",
+        "--hidden-import=zipfile",
+        "--hidden-import=tempfile",
+        "--hidden-import=ssl",
+        "--hidden-import=_ssl",
+        "--exclude-module=PyQt6",
+        "--exclude-module=qfluentwidgets",
+        "--exclude-module=numpy",
+        "--exclude-module=sounddevice",
+        "--exclude-module=soundfile",
+        "--exclude-module=pedalboard",
+        "--exclude-module=av",
+        "--exclude-module=pykakasi",
+        "--exclude-module=sudachipy",
+        "--exclude-module=sudachidict_core",
+        "--exclude-module=jaconv",
+        "--exclude-module=matplotlib",
+        "--exclude-module=scipy",
+        "--exclude-module=tkinter",
+    ]
+    icon = REPO_ROOT / "krok_helper" / "lyrics_timing" / "src" / "strange_uta_game" / "resource" / "icon.ico"
+    if icon.exists():
+        pi_args.append(f"--icon={icon}")
+    if args.clean:
+        pi_args.append("--clean")
+
+    pyinstaller.run(pi_args)
+    exe = PROJECT_ROOT / "dist" / "Updater.exe"
+    if not exe.exists():
+        print("Build finished, but dist/Updater.exe was not found.", file=sys.stderr)
+        return 1
+    print(f"Built {exe} ({exe.stat().st_size / 1024 / 1024:.1f} MB)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/krok_helper/updater_app/main.py
+++ b/krok_helper/updater_app/main.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import sys
+
+from krok_helper.lyrics_timing.updater_app import main as updater_main
+
+
+def main(argv: list[str] | None = None) -> int:
+    updater_main.TMP_DIR_NAME = "KaraokeStudioUpdater"
+    updater_main.PRODUCT_NAME = "Karaoke Studio"
+    updater_main.DEFAULT_USER_AGENT = "KaraokeStudio-Updater/standalone"
+    if argv is None:
+        return updater_main.main()
+    old_argv = sys.argv[:]
+    try:
+        sys.argv = [old_argv[0], *argv]
+        return updater_main.main()
+    finally:
+        sys.argv = old_argv
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/krok_helper/video_download/bilibili_auth.py
+++ b/krok_helper/video_download/bilibili_auth.py
@@ -34,7 +34,7 @@ class BilibiliQrLoginService:
     def __init__(self, cookie_manager: CookieManager) -> None:
         self._cookie_manager = cookie_manager
         self._cookie_jar = cookie_manager.load_cookie_jar()
-        self._opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(self._cookie_jar))
+        self._opener = cookie_manager.build_opener(urllib.request.HTTPCookieProcessor(self._cookie_jar))
 
     def request_qr_ticket(self) -> QrLoginTicket:
         payload = self._request_json(BILIBILI_QR_GENERATE_URL)
@@ -88,7 +88,7 @@ class BilibiliQrLoginService:
     def _fetch_qr_image_bytes(self, login_url: str) -> bytes:
         qr_url = QR_IMAGE_API.format(data=urllib.parse.quote(login_url, safe=""))
         try:
-            with urllib.request.urlopen(self._make_request(qr_url), timeout=20) as response:
+            with self._cookie_manager.build_opener().open(self._make_request(qr_url), timeout=20) as response:
                 return response.read()
         except Exception:
             return b""

--- a/krok_helper/video_download/cookie_manager.py
+++ b/krok_helper/video_download/cookie_manager.py
@@ -11,6 +11,13 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from krok_helper.config import APP_NAME
+from krok_helper.network import (
+    build_urllib_opener_for_app_settings,
+    load_current_app_settings,
+    proxy_cli_args_for_app_settings,
+    proxy_url_for_app_settings,
+    subprocess_env_for_app_settings,
+)
 from .download_task import SOURCE_BILIBILI, SOURCE_YOUTUBE
 
 
@@ -22,11 +29,15 @@ class BilibiliAccountProfile:
 
 
 class CookieManager:
-    def __init__(self, cookie_path: str = "") -> None:
+    def __init__(self, cookie_path: str = "", app_settings=None) -> None:
         self._configured_path = cookie_path.strip()
+        self._app_settings = app_settings
 
     def set_cookie_path(self, cookie_path: str) -> None:
         self._configured_path = cookie_path.strip()
+
+    def _settings(self):
+        return self._app_settings or load_current_app_settings()
 
     def default_cookie_path(self, platform: str = SOURCE_BILIBILI) -> Path:
         filename = "youtube_cookies.txt" if platform == SOURCE_YOUTUBE else "bilibili_cookies.txt"
@@ -38,7 +49,27 @@ class CookieManager:
     def resolved_cookie_path(self, platform: str = SOURCE_BILIBILI) -> Path:
         if platform == SOURCE_BILIBILI and self._configured_path:
             return Path(self._configured_path).expanduser()
-        return self.default_cookie_path(platform)
+        path = self.default_cookie_path(platform)
+        if path.exists():
+            return path
+        legacy = self._legacy_default_cookie_path(platform)
+        return legacy if legacy.exists() and self._is_builtin_default_cookie_path(path) else path
+
+    def _legacy_default_cookie_path(self, platform: str = SOURCE_BILIBILI) -> Path:
+        filename = "youtube_cookies.txt" if platform == SOURCE_YOUTUBE else "bilibili_cookies.txt"
+        appdata = os.getenv("APPDATA")
+        if os.name == "nt" and appdata:
+            return Path(appdata) / "Karaoke Helper" / "video_download" / filename
+        return Path.home() / ".config" / "karaoke-helper" / filename
+
+    def _is_builtin_default_cookie_path(self, path: Path) -> bool:
+        parts = path.parts
+        if os.name == "nt":
+            return len(parts) >= 3 and parts[-3] == APP_NAME and parts[-2] == "video_download"
+        return len(parts) >= 2 and parts[-2] == APP_NAME.lower().replace(" ", "-")
+
+    def build_opener(self, *handlers):
+        return build_urllib_opener_for_app_settings(self._settings(), *handlers)
 
     def has_cookie(self, platform: str = SOURCE_BILIBILI) -> bool:
         path = self.resolved_cookie_path(platform)
@@ -173,6 +204,9 @@ class CookieManager:
             "cookiesfrombrowser": (browser_name,),
             "cookiefile": str(path),
         }
+        proxy_url = proxy_url_for_app_settings(self._settings())
+        if proxy_url:
+            options["proxy"] = proxy_url
         try:
             with youtube_dl(options) as ydl:
                 ydl.cookiejar.save(str(path), ignore_discard=True, ignore_expires=True)
@@ -195,6 +229,9 @@ class CookieManager:
             "--no-update",
             "https://www.youtube.com/",
         ]
+        proxy_args = proxy_cli_args_for_app_settings(self._settings())
+        if proxy_args:
+            command[1:1] = proxy_args
         completed = subprocess.run(
             command,
             capture_output=True,
@@ -203,6 +240,7 @@ class CookieManager:
             errors="ignore",
             check=False,
             timeout=60,
+            env=subprocess_env_for_app_settings(self._settings()),
             creationflags=getattr(subprocess, "CREATE_NO_WINDOW", 0),
         )
         if completed.returncode != 0 and not path.exists():
@@ -241,7 +279,7 @@ class CookieManager:
 
     def _fetch_nav_payload(self) -> dict:
         jar = self.load_cookie_jar()
-        opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(jar))
+        opener = self.build_opener(urllib.request.HTTPCookieProcessor(jar))
         request = urllib.request.Request(
             "https://api.bilibili.com/x/web-interface/nav",
             headers={
@@ -263,7 +301,7 @@ class CookieManager:
                     "Referer": "https://www.bilibili.com/",
                 },
             )
-            with urllib.request.urlopen(request, timeout=15) as response:
+            with self.build_opener().open(request, timeout=15) as response:
                 return response.read()
         except Exception:
             return b""

--- a/krok_helper/video_download/video_download_page.py
+++ b/krok_helper/video_download/video_download_page.py
@@ -551,12 +551,13 @@ class ParseLinksWorker(QThread):
         self,
         urls: list[str],
         cookie_files_by_source: dict[str, str],
+        app_settings=None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
         self._urls = urls
         self._cookie_files_by_source = cookie_files_by_source
-        self._service = YtDlpService()
+        self._service = YtDlpService(app_settings=app_settings)
 
     def run(self) -> None:  # noqa: D401
         infos: list[VideoInfo] = []
@@ -581,11 +582,11 @@ class DownloadWorker(QThread):
     taskFailed = Signal(str, str)
     taskCancelled = Signal(str)
 
-    def __init__(self, task: DownloadTask, options: DownloadOptions, parent: QWidget | None = None) -> None:
+    def __init__(self, task: DownloadTask, options: DownloadOptions, app_settings=None, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._task = task
         self._options = options
-        self._service = YtDlpService()
+        self._service = YtDlpService(app_settings=app_settings)
 
     def run(self) -> None:  # noqa: D401
         if self._task.cancel_requested:
@@ -629,8 +630,12 @@ class YtDlpUpdateWorker(QThread):
     updateSucceeded = Signal(str, str)
     updateFailed = Signal(str)
 
+    def __init__(self, app_settings=None, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._app_settings = app_settings
+
     def run(self) -> None:  # noqa: D401
-        service = YtDlpService()
+        service = YtDlpService(app_settings=self._app_settings)
         try:
             before_version = service.get_ytdlp_version()
             update_output = service.update_ytdlp()
@@ -698,7 +703,7 @@ class VideoDownloadPage(QWidget):
         super().__init__(parent)
         self.settings = settings
         self._save_settings = save_settings
-        self.cookie_manager = CookieManager(getattr(settings, "video_download_cookie_path", ""))
+        self.cookie_manager = CookieManager(getattr(settings, "video_download_cookie_path", ""), app_settings=settings)
         self._parse_worker: ParseLinksWorker | None = None
         self._cookie_import_worker: CookieImportWorker | None = None
         self._ytdlp_update_worker: YtDlpUpdateWorker | None = None
@@ -1714,7 +1719,7 @@ class VideoDownloadPage(QWidget):
 
     def _current_ytdlp_version_text(self) -> str:
         try:
-            return YtDlpService().get_ytdlp_version()
+            return YtDlpService(app_settings=self.settings).get_ytdlp_version()
         except Exception as exc:  # noqa: BLE001
             return f"未检测到：{exc}"
 
@@ -1738,7 +1743,7 @@ class VideoDownloadPage(QWidget):
         update_button.setEnabled(False)
         version_label.setText("正在更新 yt-dlp…")
         self.parse_status_label.setText("正在更新 yt-dlp，请稍候。")
-        worker = YtDlpUpdateWorker(self)
+        worker = YtDlpUpdateWorker(self.settings, self)
         self._ytdlp_update_worker = worker
         worker.updateSucceeded.connect(
             lambda version, output: self._handle_ytdlp_update_succeeded(version_label, version, output)
@@ -1894,7 +1899,7 @@ class VideoDownloadPage(QWidget):
         }
         self.parse_button.setEnabled(False)
         self.parse_status_label.setText(f"正在解析 {len(urls)} 个链接…")
-        self._parse_worker = ParseLinksWorker(urls, cookie_files_by_source, self)
+        self._parse_worker = ParseLinksWorker(urls, cookie_files_by_source, self.settings, self)
         self._parse_worker.batchFinished.connect(self._handle_parse_finished)
         self._parse_worker.finished.connect(self._handle_parse_worker_finished)
         self._parse_worker.start()
@@ -2747,7 +2752,7 @@ class VideoDownloadPage(QWidget):
             task.status = TASK_STATUS_DOWNLOADING
             self._reset_task_progress_tracking(task)
             options = self._build_download_options(task)
-            worker = DownloadWorker(task, options, self)
+            worker = DownloadWorker(task, options, self.settings, self)
             worker.progressChanged.connect(self._handle_download_progress)
             worker.taskSucceeded.connect(self._handle_download_success)
             worker.taskFailed.connect(self._handle_download_failed)

--- a/krok_helper/video_download/ytdlp_service.py
+++ b/krok_helper/video_download/ytdlp_service.py
@@ -11,6 +11,14 @@ import urllib.request
 from pathlib import Path
 from typing import Any, Callable
 
+from krok_helper.network import (
+    build_urllib_opener_for_app_settings,
+    load_current_app_settings,
+    proxy_cli_args_for_app_settings,
+    proxy_url_for_app_settings,
+    subprocess_env_for_app_settings,
+)
+
 from .download_task import (
     DownloadOptions,
     DownloadTask,
@@ -38,8 +46,12 @@ class DownloadCancelledError(VideoDownloadError):
 
 
 class YtDlpService:
-    def __init__(self, format_parser: FormatParser | None = None) -> None:
+    def __init__(self, format_parser: FormatParser | None = None, app_settings=None) -> None:
         self._format_parser = format_parser or FormatParser()
+        self._app_settings = app_settings
+
+    def _settings(self):
+        return self._app_settings or load_current_app_settings()
 
     def get_ytdlp_version(self) -> str:
         try:
@@ -54,6 +66,7 @@ class YtDlpService:
                 errors="ignore",
                 check=False,
                 timeout=15,
+                env=subprocess_env_for_app_settings(self._settings()),
                 creationflags=self._subprocess_creationflags(),
             )
             if completed.returncode != 0:
@@ -69,7 +82,7 @@ class YtDlpService:
             headers={"User-Agent": "krok-helper"},
         )
         try:
-            with urllib.request.urlopen(request, timeout=15) as response:
+            with build_urllib_opener_for_app_settings(self._settings()).open(request, timeout=15) as response:
                 payload = json.load(response)
         except Exception as exc:  # noqa: BLE001
             raise VideoDownloadError(f"无法查询 yt-dlp 最新版本：{exc}") from exc
@@ -283,6 +296,9 @@ class YtDlpService:
             ydl_opts["cookiefile"] = cookie_file
         if extractor_args_hint:
             ydl_opts["extractor_args"] = self._build_python_extractor_args(extractor_args_hint)
+        proxy_url = proxy_url_for_app_settings(self._settings())
+        if proxy_url:
+            ydl_opts["proxy"] = proxy_url
 
         try:
             with youtube_dl(ydl_opts) as ydl:
@@ -333,6 +349,9 @@ class YtDlpService:
             command[1:1] = ["--extractor-args", extractor_args_hint]
         if cookie_file and Path(cookie_file).is_file():
             command[1:1] = ["--cookies", cookie_file]
+        proxy_args = proxy_cli_args_for_app_settings(self._settings())
+        if proxy_args:
+            command[1:1] = proxy_args
 
         try:
             completed = subprocess.run(
@@ -343,6 +362,7 @@ class YtDlpService:
                 errors="ignore",
                 check=False,
                 timeout=60,
+                env=subprocess_env_for_app_settings(self._settings()),
                 creationflags=self._subprocess_creationflags(),
             )
         except Exception as exc:  # noqa: BLE001
@@ -431,6 +451,9 @@ class YtDlpService:
             ydl_opts["merge_output_format"] = "mp4"
         if options.cookie_file and Path(options.cookie_file).is_file():
             ydl_opts["cookiefile"] = options.cookie_file
+        proxy_url = proxy_url_for_app_settings(self._settings())
+        if proxy_url:
+            ydl_opts["proxy"] = proxy_url
 
         before_pids = self._snapshot_child_pids()
         done_event = threading.Event()
@@ -534,6 +557,7 @@ class YtDlpService:
             command.extend(["--merge-output-format", "mp4"])
         if options.cookie_file and Path(options.cookie_file).is_file():
             command.extend(["--cookies", options.cookie_file])
+        command.extend(proxy_cli_args_for_app_settings(self._settings()))
         command.append(task.url)
 
         before_pids = self._snapshot_child_pids()
@@ -544,6 +568,7 @@ class YtDlpService:
             text=True,
             encoding="utf-8",
             errors="ignore",
+            env=subprocess_env_for_app_settings(self._settings()),
             creationflags=self._subprocess_creationflags(),
         )
         done_event = threading.Event()
@@ -632,7 +657,7 @@ class YtDlpService:
     def _update_ytdlp_cli(self) -> str:
         cli = self._find_ytdlp_cli()
         try:
-            return self._run_update_command([cli, "-U"])
+            return self._run_update_command([cli, *proxy_cli_args_for_app_settings(self._settings()), "-U"])
         except VideoDownloadError as exc:
             message = str(exc)
             if self._should_fallback_to_pip_update(message):
@@ -686,6 +711,7 @@ class YtDlpService:
                 errors="ignore",
                 check=False,
                 timeout=180,
+                env=subprocess_env_for_app_settings(self._settings()),
                 creationflags=self._subprocess_creationflags(),
             )
         except Exception as exc:  # noqa: BLE001
@@ -735,7 +761,7 @@ class YtDlpService:
         if not url:
             return b""
         try:
-            with urllib.request.urlopen(url, timeout=10) as response:
+            with build_urllib_opener_for_app_settings(self._settings()).open(url, timeout=10) as response:
                 return response.read()
         except Exception:
             return b""

--- a/scripts/build_macos.command
+++ b/scripts/build_macos.command
@@ -5,11 +5,15 @@ PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 PYTHON_BIN="${PYTHON_BIN:-python3}"
-APP_NAME="Karaoke Helper"
+APP_NAME="Karaoke Studio"
 DIST_PATH="$PROJECT_ROOT/dist/macos"
 WORK_PATH="$PROJECT_ROOT/build/pyinstaller-macos"
 SPEC_PATH="$PROJECT_ROOT/build/spec-macos"
 APP_DIST="$DIST_PATH/$APP_NAME.app"
+SUG_SRC="$PROJECT_ROOT/krok_helper/lyrics_timing/src"
+SUG_PACKAGE="$SUG_SRC/strange_uta_game"
+SUG_VERSION_FILE="$SUG_PACKAGE/__version__.py"
+SUG_VERSION_BACKUP=""
 
 EXCLUDED_MODULES=(
   PySide6
@@ -49,6 +53,16 @@ EXCLUDED_MODULES=(
   PyQt6.QtWebEngineWidgets
   PyQt6.QtWebSockets
   PyQt6.QtWebView
+  winrt
+  winrt.windows.globalization
+  winrt.windows.foundation
+  sudachidict_core
+  sudachidict_full
+  scipy
+  matplotlib
+  pandas
+  pytest
+  PIL
 )
 
 KEEP_TRANSLATIONS=(
@@ -121,6 +135,51 @@ ensure_pkg PyInstaller pyinstaller
 ensure_pkg PyQt6 PyQt6
 ensure_pkg qfluentwidgets "PyQt6-Fluent-Widgets"
 ensure_pkg yt_dlp yt-dlp
+ensure_pkg requests requests
+ensure_pkg psutil psutil
+ensure_pkg sounddevice sounddevice
+ensure_pkg soundfile soundfile
+ensure_pkg pedalboard pedalboard
+ensure_pkg numpy numpy
+ensure_pkg pykakasi pykakasi
+ensure_pkg jaconv jaconv
+ensure_pkg sudachipy sudachipy
+ensure_pkg sudachidict_small sudachidict_small
+
+echo "Checking bundled SUG source path..."
+"$PYTHON_BIN" - <<PY
+import sys
+from pathlib import Path
+src = Path(r"$SUG_SRC").resolve()
+sys.path.insert(0, str(src))
+import strange_uta_game
+actual = Path(strange_uta_game.__file__).resolve()
+expected = src / "strange_uta_game" / "__init__.py"
+print(f"  strange_uta_game: {actual}")
+raise SystemExit(0 if actual == expected else f"Expected {expected}, got {actual}")
+PY
+
+SUG_VERSION_BACKUP="$(mktemp)"
+cp "$SUG_VERSION_FILE" "$SUG_VERSION_BACKUP"
+restore_sug_version() {
+  if [ -n "$SUG_VERSION_BACKUP" ] && [ -f "$SUG_VERSION_BACKUP" ]; then
+    cp "$SUG_VERSION_BACKUP" "$SUG_VERSION_FILE"
+    rm -f "$SUG_VERSION_BACKUP"
+  fi
+}
+trap restore_sug_version EXIT
+
+echo "Setting SUG package variant to mac for this build..."
+"$PYTHON_BIN" - <<PY
+from pathlib import Path
+import re
+path = Path(r"$SUG_VERSION_FILE")
+text = path.read_text(encoding="utf-8")
+patched = re.sub(r'^(VARIANT\s*=\s*)"[^"]*"', r'\1"mac"', text, flags=re.MULTILINE)
+if patched == text:
+    raise SystemExit("Could not patch VARIANT in strange_uta_game/__version__.py")
+path.write_text(patched, encoding="utf-8")
+PY
 
 mkdir -p "$DIST_PATH" "$WORK_PATH" "$SPEC_PATH"
 
@@ -133,9 +192,37 @@ PYINSTALLER_ARGS=(
   --distpath "$DIST_PATH"
   --workpath "$WORK_PATH"
   --specpath "$SPEC_PATH"
+  --paths "$SUG_SRC"
   --add-data "$PROJECT_ROOT/krok_helper/assets:krok_helper/assets"
+  --add-data "$SUG_PACKAGE/config:strange_uta_game/config"
+  --add-data "$SUG_PACKAGE/resource:strange_uta_game/resource"
+  --add-data "$SUG_PACKAGE/bass:strange_uta_game/bass"
   --collect-all qfluentwidgets
   --collect-all yt_dlp
+  --collect-all sounddevice
+  --collect-all soundfile
+  --collect-all pedalboard
+  --collect-all pykakasi
+  --collect-all sudachipy
+  --collect-data sudachidict_small
+  --collect-binaries soundfile
+  --collect-submodules strange_uta_game
+  --hidden-import sounddevice
+  --hidden-import soundfile
+  --hidden-import pedalboard
+  --hidden-import pedalboard.io
+  --hidden-import pedalboard.io.AudioFile
+  --hidden-import pedalboard.io.StreamResampler
+  --hidden-import pedalboard.time_stretch
+  --hidden-import numpy
+  --hidden-import pykakasi
+  --hidden-import pykakasi.kakasi
+  --hidden-import jaconv
+  --hidden-import sudachipy
+  --hidden-import sudachidict_small
+  --hidden-import PyQt6.sip
+  --hidden-import encodings.idna
+  --hidden-import colorsys
 )
 
 for module in "${EXCLUDED_MODULES[@]}"; do
@@ -196,6 +283,42 @@ for rel in "${REMOVE_QT_LIBS[@]}"; do
     rm -rf "$target"
   done < <(find "$APP_DIST" -name "$rel" -print0)
 done
+
+echo "Validating macOS package contents..."
+APP_INTERNAL="$APP_DIST/Contents/Frameworks"
+if [ ! -d "$APP_INTERNAL" ]; then
+  APP_INTERNAL="$APP_DIST/Contents/Resources"
+fi
+if [ ! -d "$APP_INTERNAL" ]; then
+  echo "Could not locate PyInstaller internal directory in $APP_DIST"
+  exit 1
+fi
+
+REQUIRED_FILES=(
+  "krok_helper/assets/logo/logo.jpg"
+  "krok_helper/assets/platforms/youtube.svg"
+  "strange_uta_game/config/config.json"
+  "strange_uta_game/config/dictionary.json"
+  "strange_uta_game/config/cmudict-0.7b"
+  "strange_uta_game/config/kanji_readings.json"
+  "strange_uta_game/resource/icon.ico"
+  "strange_uta_game/resource/sounds/press.wav"
+)
+missing=0
+for rel in "${REQUIRED_FILES[@]}"; do
+  if [ ! -f "$APP_INTERNAL/$rel" ]; then
+    echo "Missing package file: $APP_INTERNAL/$rel"
+    missing=1
+  fi
+done
+if [ "$missing" -ne 0 ]; then
+  exit 1
+fi
+warn_file="$(find "$WORK_PATH" -name 'warn-*.txt' -type f -print -quit || true)"
+if [ -n "$warn_file" ]; then
+  echo "PyInstaller warnings were written to: $warn_file"
+fi
+echo "Package content validation passed."
 
 echo
 echo "Build complete:"

--- a/scripts/build_windows.bat
+++ b/scripts/build_windows.bat
@@ -5,13 +5,15 @@ setlocal
 cd /d "%~dp0\.."
 
 set "PYTHON_BIN=python"
-set "BUILD_NAME=KaraokeHelper"
-set "APP_NAME=Karaoke Helper"
+set "BUILD_NAME=KaraokeStudio"
+set "APP_NAME=Karaoke Studio"
 set "DIST_PATH=dist\windows"
 set "WORK_PATH=build\pyinstaller-windows"
 set "SPEC_PATH=build\spec-windows"
 set "APP_DIST=%DIST_PATH%\%APP_NAME%"
 set "BUILD_DIST=%DIST_PATH%\%BUILD_NAME%"
+set "SUG_SRC=%CD%\krok_helper\lyrics_timing\src"
+set "SUG_PACKAGE=%SUG_SRC%\strange_uta_game"
 set "IS_CI="
 if defined CI set "IS_CI=1"
 
@@ -28,19 +30,29 @@ call :ensure_pkg PyQt6 PyQt6 || exit /b 1
 call :ensure_pkg qfluentwidgets "PyQt6-Fluent-Widgets" || exit /b 1
 call :ensure_pkg yt_dlp yt-dlp || exit /b 1
 call :ensure_pkg requests requests || exit /b 1
+call :ensure_pkg psutil psutil || exit /b 1
+call :ensure_pkg sounddevice sounddevice || exit /b 1
+call :ensure_pkg soundfile soundfile || exit /b 1
+call :ensure_pkg pedalboard pedalboard || exit /b 1
+call :ensure_pkg numpy numpy || exit /b 1
+call :ensure_pkg pykakasi pykakasi || exit /b 1
+call :ensure_pkg jaconv jaconv || exit /b 1
+call :ensure_pkg winrt.windows.globalization winrt-Windows.Globalization || exit /b 1
+call :ensure_pkg winrt.windows.foundation winrt-Windows.Foundation || exit /b 1
+call :ensure_pkg winrt.windows.foundation.collections winrt-Windows.Foundation.Collections || exit /b 1
 
-if not exist "krok_helper\lyrics_timing\updater_app\dist\Updater.exe" (
+echo Checking bundled SUG source path...
+%PYTHON_BIN% -c "import sys; from pathlib import Path; src=Path(r'%SUG_SRC%').resolve(); sys.path.insert(0, str(src)); import strange_uta_game; actual=Path(strange_uta_game.__file__).resolve(); expected=src/'strange_uta_game'/'__init__.py'; print('  strange_uta_game:', actual); raise SystemExit(0 if actual == expected else f'Expected {expected}, got {actual}')" || exit /b 1
+
+if not exist "krok_helper\updater_app\dist\Updater.exe" (
     echo Building Updater.exe...
-    pushd krok_helper\lyrics_timing
-    %PYTHON_BIN% updater_app\build_updater.py
+    %PYTHON_BIN% krok_helper\updater_app\build_updater.py
     if errorlevel 1 (
-        popd
         echo.
         echo Updater build failed.
         if not defined IS_CI pause
         exit /b 1
     )
-    popd
 )
 
 if not exist "%DIST_PATH%" mkdir "%DIST_PATH%"
@@ -59,9 +71,46 @@ echo Building Windows package...
     --distpath "%DIST_PATH%" ^
     --workpath "%WORK_PATH%" ^
     --specpath "%SPEC_PATH%" ^
+    --paths "%SUG_SRC%" ^
     --add-data "%CD%\krok_helper\assets;krok_helper\assets" ^
+    --add-data "%SUG_PACKAGE%\config;strange_uta_game\config" ^
+    --add-data "%SUG_PACKAGE%\resource;strange_uta_game\resource" ^
+    --add-data "%SUG_PACKAGE%\bass;strange_uta_game\bass" ^
     --collect-all qfluentwidgets ^
     --collect-all yt_dlp ^
+    --collect-all sounddevice ^
+    --collect-all soundfile ^
+    --collect-all pedalboard ^
+    --collect-all pykakasi ^
+    --collect-all winrt ^
+    --collect-binaries soundfile ^
+    --collect-submodules strange_uta_game ^
+    --hidden-import sounddevice ^
+    --hidden-import soundfile ^
+    --hidden-import pedalboard ^
+    --hidden-import pedalboard.io ^
+    --hidden-import pedalboard.io.AudioFile ^
+    --hidden-import pedalboard.io.StreamResampler ^
+    --hidden-import pedalboard.time_stretch ^
+    --hidden-import numpy ^
+    --hidden-import pykakasi ^
+    --hidden-import pykakasi.kakasi ^
+    --hidden-import jaconv ^
+    --hidden-import PyQt6.sip ^
+    --hidden-import encodings.idna ^
+    --hidden-import colorsys ^
+    --hidden-import winrt.windows.globalization ^
+    --hidden-import winrt.windows.foundation ^
+    --hidden-import winrt.windows.foundation.collections ^
+    --exclude-module sudachipy ^
+    --exclude-module sudachidict_small ^
+    --exclude-module sudachidict_core ^
+    --exclude-module sudachidict_full ^
+    --exclude-module scipy ^
+    --exclude-module matplotlib ^
+    --exclude-module pandas ^
+    --exclude-module pytest ^
+    --exclude-module PIL ^
     --exclude-module PySide6 ^
     --exclude-module PyQt5 ^
     --exclude-module PyQt6.Qt3DAnimation ^
@@ -153,11 +202,42 @@ if errorlevel 1 (
 echo Copying Updater.exe...
 powershell -NoProfile -ExecutionPolicy Bypass -Command ^
     "$targetDir = Resolve-Path '%APP_DIST%';" ^
-    "$updater = Resolve-Path 'krok_helper\lyrics_timing\updater_app\dist\Updater.exe';" ^
+    "$updater = Resolve-Path 'krok_helper\updater_app\dist\Updater.exe';" ^
     "Copy-Item -LiteralPath $updater -Destination (Join-Path $targetDir 'Updater.exe') -Force"
 if errorlevel 1 (
     echo.
     echo Failed to copy Updater.exe.
+    if not defined IS_CI pause
+    exit /b 1
+)
+
+echo Validating Windows package contents...
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+    "$targetDir = Resolve-Path '%APP_DIST%';" ^
+    "$internal = Join-Path $targetDir '_internal';" ^
+    "$required = @(" ^
+    "  'krok_helper\assets\logo\logo.jpg'," ^
+    "  'krok_helper\assets\platforms\youtube.svg'," ^
+    "  'strange_uta_game\config\config.json'," ^
+    "  'strange_uta_game\config\dictionary.json'," ^
+    "  'strange_uta_game\config\cmudict-0.7b'," ^
+    "  'strange_uta_game\config\kanji_readings.json'," ^
+    "  'strange_uta_game\resource\icon.ico'," ^
+    "  'strange_uta_game\resource\sounds\press.wav'," ^
+    "  'strange_uta_game\bass\x64\bass.dll'," ^
+    "  'strange_uta_game\bass\x64\bass_fx.dll'," ^
+    "  'Updater.exe'" ^
+    ");" ^
+    "$missing = @();" ^
+    "foreach ($rel in $required) { $base = if ($rel -eq 'Updater.exe') { $targetDir } else { $internal }; $path = Join-Path $base $rel; if (-not (Test-Path $path -PathType Leaf)) { $missing += $path } };" ^
+    "if ($missing.Count) { Write-Host 'Missing package files:'; $missing | ForEach-Object { Write-Host ('  ' + $_) }; exit 1 };" ^
+    "$warnRoot = Join-Path '%WORK_PATH%' '%BUILD_NAME%';" ^
+    "$warn = if (Test-Path $warnRoot) { Get-ChildItem -LiteralPath $warnRoot -Recurse -Filter 'warn-*.txt' -File -ErrorAction SilentlyContinue | Select-Object -First 1 } else { $null };" ^
+    "if ($warn) { Write-Host ('PyInstaller warnings were written to: ' + $warn.FullName) };" ^
+    "Write-Host 'Package content validation passed.'"
+if errorlevel 1 (
+    echo.
+    echo Package validation failed.
     if not defined IS_CI pause
     exit /b 1
 )

--- a/tests/test_workbench_updater.py
+++ b/tests/test_workbench_updater.py
@@ -5,17 +5,18 @@ import sys
 from krok_helper.settings import AppSettings
 from krok_helper.updater.settings import UpdaterSettings, ensure_updater_settings
 from krok_helper.updater.sources import build_api_urls, build_release_urls, normalize_order
+from krok_helper.updater.installer import DEFAULT_APP_EXE_NAME, TMP_DIR_NAME, LaunchPlan
 from krok_helper.updater.worker import LatestRelease, ReleaseAsset, current_asset_name, is_newer_version
 
 
 def test_workbench_updater_uses_workbench_repo_urls() -> None:
     api_urls = build_api_urls(["github"])
-    release_urls = build_release_urls(["github"], "v3.0.1", "KaraokeHelper-windows.zip")
+    release_urls = build_release_urls(["github"], "v3.0.1", "KaraokeStudio-windows.zip")
 
     assert api_urls[0][1] == "https://api.github.com/repos/karaoke-studio/karaoke-studio/releases/latest"
     assert release_urls[0][1] == (
         "https://github.com/karaoke-studio/karaoke-studio/"
-        "releases/download/v3.0.1/KaraokeHelper-windows.zip"
+        "releases/download/v3.0.1/KaraokeStudio-windows.zip"
     )
 
 
@@ -49,9 +50,30 @@ def test_workbench_updater_version_and_asset_selection(monkeypatch) -> None:
         html_url="",
         prerelease=False,
         published_at="",
-        assets=[ReleaseAsset("KaraokeHelper-windows.zip", 10, "https://example.invalid/app.zip")],
+        assets=[ReleaseAsset("KaraokeStudio-windows.zip", 10, "https://example.invalid/app.zip")],
     )
 
     assert is_newer_version("3.0.1", "3.0.0")
-    assert current_asset_name() == "KaraokeHelper-windows.zip"
-    assert release.pick_primary_asset("KaraokeHelper-windows.zip") is not None
+    assert current_asset_name() == "KaraokeStudio-windows.zip"
+    assert release.pick_primary_asset("KaraokeStudio-windows.zip") is not None
+
+
+def test_workbench_updater_launcher_is_workbench_scoped(tmp_path) -> None:
+    plan = LaunchPlan(
+        app_dir=tmp_path,
+        app_exe_name=DEFAULT_APP_EXE_NAME,
+        target_version="3.0.1",
+        target_tag="v3.0.1",
+        asset_name="KaraokeStudio-windows.zip",
+        download_urls=[("github", "https://example.invalid/KaraokeStudio-windows.zip")],
+        proxy_url="http://127.0.0.1:7890",
+    )
+
+    args = plan.command_args(tmp_path / "Updater.exe", current_pid=1234)
+
+    assert TMP_DIR_NAME == "KaraokeStudioUpdater"
+    assert DEFAULT_APP_EXE_NAME == "Karaoke Studio.exe"
+    assert "--app-exe" in args
+    assert args[args.index("--app-exe") + 1] == "Karaoke Studio.exe"
+    assert "KaraokeStudio-windows.zip" in args
+    assert "StrangeUtaGame" not in " ".join(args)

--- a/tests/video_download/test_proxy_usage.py
+++ b/tests/video_download/test_proxy_usage.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import json
+import subprocess
+
+from krok_helper.network import proxy_cli_args_for_app_settings, subprocess_env_for_app_settings
+from krok_helper.settings import AppSettings
+from krok_helper.video_download.ytdlp_service import YtDlpService
+
+
+def _settings_with_manual_proxy() -> AppSettings:
+    return AppSettings(
+        updater={
+            "proxy": {
+                "mode": "manual",
+                "manual_url": "127.0.0.1:7890",
+            }
+        }
+    )
+
+
+def test_global_proxy_builds_cli_args_and_subprocess_env() -> None:
+    settings = _settings_with_manual_proxy()
+
+    assert proxy_cli_args_for_app_settings(settings) == ["--proxy", "http://127.0.0.1:7890"]
+    env = subprocess_env_for_app_settings(settings)
+    assert env["HTTP_PROXY"] == "http://127.0.0.1:7890"
+    assert env["HTTPS_PROXY"] == "http://127.0.0.1:7890"
+
+
+def test_ytdlp_cli_extract_uses_global_proxy(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    service = YtDlpService(app_settings=_settings_with_manual_proxy())
+    monkeypatch.setattr(service, "_find_ytdlp_cli", lambda: "yt-dlp")
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps({"title": "ok", "duration": 1, "formats": []}),
+            stderr="",
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    service._extract_info_with_cli("https://www.youtube.com/watch?v=abc")
+
+    command = captured["command"]
+    assert isinstance(command, list)
+    assert command[1:3] == ["--proxy", "http://127.0.0.1:7890"]
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["HTTPS_PROXY"] == "http://127.0.0.1:7890"
+

--- a/tests/video_download/test_settings_roundtrip.py
+++ b/tests/video_download/test_settings_roundtrip.py
@@ -71,6 +71,17 @@ def test_load_with_unknown_keys_doesnt_crash(tmp_path, monkeypatch) -> None:
     assert load_app_settings().video_download_save_dir == "D:/Downloads"
 
 
+def test_load_falls_back_to_legacy_karaoke_helper_settings(tmp_path, monkeypatch) -> None:
+    settings_path = tmp_path / "Karaoke Studio" / "settings.json"
+    legacy_path = tmp_path / "Karaoke Helper" / "settings.json"
+    legacy_path.parent.mkdir(parents=True)
+    legacy_path.write_text(json.dumps({"video_download_save_dir": "D:/LegacyDownloads"}), encoding="utf-8")
+    monkeypatch.setattr("krok_helper.settings.get_settings_path", lambda: settings_path)
+    monkeypatch.setattr("krok_helper.settings.get_legacy_settings_paths", lambda: [legacy_path])
+
+    assert load_app_settings().video_download_save_dir == "D:/LegacyDownloads"
+
+
 def test_load_invalid_waveform_alignment_choices_falls_back(tmp_path, monkeypatch) -> None:
     settings_path = tmp_path / "settings.json"
     settings_path.write_text(


### PR DESCRIPTION
﻿## Summary

This PR fixes the workbench update path and network proxy coverage after the app rename to Karaoke Studio.

## What changed

- Renamed the workbench packaging/identity from `Karaoke Helper` to `Karaoke Studio`.
- Added migration fallback for legacy `Karaoke Helper` settings and cookie paths.
- Split the workbench updater launcher/build entry from the vendored SUG updater path.
- Updated release asset names to `KaraokeStudio-windows.zip` and `KaraokeStudio-macos.zip`.
- Added shared proxy resolution helpers and wired global proxy settings into update checks, updater launch, yt-dlp operations, thumbnail/PyPI requests, Bilibili auth/cookie checks, and lyric network requests.
- Updated Windows/macOS build scripts and README paths.

## Why

The packaged `Updater.exe` and launch path were still coming from the vendored SUG module, which made the workbench update flow look and behave like it was scoped to SUG. The global proxy setting also did not consistently apply to all network operations.

## Validation

- `python -m pytest tests`
- `python -m pytest tests/video_download`
- `cmd /c scripts\build_windows.bat`
- `dist\windows\Karaoke Studio\Karaoke Studio.exe --help`
- `dist\windows\Karaoke Studio\Updater.exe --help`
