### PR TITLE
fix(ai_timing): 修复下载镜像不生效 / 分离模型镜像预下载 / AI 依赖清单外置

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,6 @@ docs/superpowers/
 # AI 会话产物（计划文件/探针输出，不入库）
 .zcode/
 .test_sessions/
+
+# AI 模型文件（需额外下载，不入库）
+ai_models/

--- a/README_DEV.md
+++ b/README_DEV.md
@@ -113,6 +113,7 @@ StrangeUtaGame/
 ├── requirements.txt                # 生产依赖（锁定版本）
 ├── requirements-winrt.txt          # main 变体注音依赖（WinRT）
 ├── requirements-variants.txt       # noWinIME / mac 变体注音依赖（sudachi）
+├── requirements-ai.txt             # AI 打轴运行依赖（PyTorch/Transformers/分离等）
 ├── requirements-dev.txt            # 开发依赖
 ├── pyproject.toml                  # 工具配置（ruff/black/mypy/pytest；不承载安装依赖）
 ├── RELEASING.md                    # 发布流程说明
@@ -182,9 +183,40 @@ pip install -r requirements-winrt.txt
 # 安装开发依赖
 pip install -r requirements-dev.txt
 
+# （可选）需要使用 AI 打轴功能时，把 AI 运行依赖装进当前解释器：
+# 装完后打开 AI 打轴弹窗会检测到当前解释器已具备全部依赖并直接复用，
+# 不必再经「安装 / 修复」新建隔离 venv。
+#   - CPU / macOS：直接装本文件即可；
+#   - Windows + NVIDIA GPU（CUDA）：见 requirements-ai.txt 文末注释。
+# 详见下方「AI 打轴运行环境」。
+pip install -r requirements-ai.txt
+
 # 运行应用
 python main.py
 ```
+
+### AI 打轴运行环境
+
+AI 打轴（forced alignment + 人声分离）的重型依赖（PyTorch / Transformers /
+audio-separator 等）**不在** `requirements.txt` 中，以免污染主程序环境并与其
+锁定的 `numpy==2.4.4` 冲突。对普通用户，这些依赖由「AI 打轴」弹窗里的
+「对齐环境 → 安装 / 修复」在**隔离 venv**（`ai_runtime/`）中自动安装。
+
+作为**源码部署**者，如果你希望 AI 打轴**直接复用自己的 Python 环境**（而不
+另建隔离 venv），可执行：
+
+```bash
+pip install -r requirements-ai.txt
+```
+
+装完后，打开 AI 打轴弹窗时，检测（probe）会发现当前解释器已具备全部 AI
+依赖并**直接复用**它，不会把你引去新建隔离 venv。清单内容、可选 CUDA 追加
+方式与 `runtime.py` 的同步关系见 [requirements-ai.txt](requirements-ai.txt)。
+
+> 注：程序只在 `runtime_python` 设置**为空**时以当前解释器（`sys.executable`）
+> 作为默认探测/执行目标。若你此前点过「安装 / 修复」，该设置会被写成本地
+> 隔离 venv 的路径；想切回复用当前解释器，清空设置中 `ai_timing.runtime_python`
+> 即可。
 
 ### 开发工具
 

--- a/requirements-ai.txt
+++ b/requirements-ai.txt
@@ -1,0 +1,38 @@
+# StrangeUtaGame —— AI 打轴运行环境依赖
+#
+# AI 打轴（强制对齐 + 人声分离）的重型依赖不随 requirements.txt 安装（那里
+# 只装主程序；往主环境塞这套会与 numpy==2.4.4 等锁定依赖冲突）。
+#
+# 这份清单面向「以源码部署、想复用自己的 Python 环境」的开发者：
+#   pip install -r requirements.txt -r requirements-ai.txt
+# 装进当前解释器后，打开 AI 打轴弹窗时 probe 会检测到该解释器已具备全部
+# 依赖，从而直接复用它——不必再走「安装 / 修复」新建隔离 venv。
+#
+# 内容与 backend/application/ai_timing/runtime.py 的 RUNTIME_REQUIREMENTS
+# 保持一致（改动需两处同步）：
+#   - 纯 CPU / macOS / 无独显机器：本文件即为完整依赖；
+#   - Windows NVIDIA（需 CUDA）：见文末注释追加 PyTorch CUDA 索引。
+#
+# 若你想隔离管理而非污染主环境，仍可在 UI「对齐环境 → 安装 / 修复」让程序
+# 新建独立 venv（内部使用同一份依赖集），或自行 python -m venv 后装本文件。
+
+# —— AI 对齐 / 人声分离核心 ——
+# 注意：Windows 上 PyPI 的 torch 默认是 CPU-only wheel；GPU 推理需显式走
+# PyTorch CUDA 索引并钉版本，见文末。librosa 钉 0.10.2.post1：audio-separator
+# 0.44.x 使用其 get_duration(filename=) 旧 API，0.11 起已移除。
+torch
+torchaudio
+transformers==5.15.0
+soundfile
+huggingface_hub
+audio-separator[cpu]
+librosa==0.10.2.post1
+
+# ---------------------------------------------------------------------------
+# Windows + NVIDIA GPU（CUDA）可选追加
+# ---------------------------------------------------------------------------
+# 上面的 torch/torchaudio 在 Windows 上装到的是 CPU 版。若要 CUDA 推理，改用：
+#   pip install torch==2.11.0+cu128 torchaudio==2.11.0+cu128 \
+#       --extra-index-url https://download.pytorch.org/whl/cu128
+# 之后再执行上方其余行的安装（transformers/soundfile/... 来自 PyPI）。
+# RTX 50 系（Blackwell）需要 cu128 及以上；NVIDIA 驱动须 ≥ 570.65。

--- a/src/strange_uta_game/backend/application/ai_timing/models.py
+++ b/src/strange_uta_game/backend/application/ai_timing/models.py
@@ -323,6 +323,14 @@ class HfHubTransport(ModelDownloadTransport):
         self._hf_cache_root = hf_cache_root
         self._proxies = {"http": proxy, "https": proxy} if proxy else None
 
+    def set_endpoint(self, endpoint: str = "") -> None:
+        """动态更换下载端点（镜像热更新；空串 = 官方源）。
+
+        transport 在弹窗构造时按当时设置创建；用户在弹窗内改「下载镜像」
+        后必须调用本方法，否则下载仍走旧端点（此前该设置形同虚设）。
+        """
+        self._endpoint = (endpoint or "https://huggingface.co").rstrip("/")
+
     def _proxies_kwargs(self) -> dict:
         return {"proxies": self._proxies} if self._proxies else {}
 
@@ -430,6 +438,19 @@ class ModelDownloadService:
     def __init__(self, registry: ModelRegistry, transport: ModelDownloadTransport):
         self._registry = registry
         self._transport = transport
+
+    def set_endpoint(self, endpoint: str = "") -> None:
+        """把下载端点同步到 transport（弹窗内改镜像后调用）。
+
+        transport 支持 ``set_endpoint``（HfHubTransport）时动态更换；不
+        支持（自定义 transport）时静默跳过，仍按其自身默认端点下载。
+        """
+        setter = getattr(self._transport, "set_endpoint", None)
+        if callable(setter):
+            try:
+                setter(endpoint)
+            except Exception:  # pragma: no cover - 防御自定义 transport
+                pass
 
     def download(
         self,

--- a/src/strange_uta_game/backend/application/ai_timing/runtime.py
+++ b/src/strange_uta_game/backend/application/ai_timing/runtime.py
@@ -387,8 +387,14 @@ def _github_mirror_candidates(
     镜像顺序跟随「设置 → 网络与代理」的更新源排序（用户把 gh-proxy 拖到
     第一位时 AI 打轴下载也镜像优先）。非 GitHub URL（如 torch wheel 的
     ``download-r2.pytorch.org``）返回空列表——gh-proxy 只代理 GitHub。
+
+    支持 ``github.com``（release 直链）与 ``raw.githubusercontent.com``
+    （raw 文件）两种 host：gh-proxy 前缀对两者都以「前缀 + 完整原始 URL」
+    的整体包装方式工作（audio-separator 的分离模型与元数据即来自这两者）。
     """
-    if not url.startswith("https://github.com/"):
+    is_github = url.startswith("https://github.com/")
+    is_raw = url.startswith("https://raw.githubusercontent.com/")
+    if not (is_github or is_raw):
         return []
     try:
         from strange_uta_game.updater.sources import (

--- a/src/strange_uta_game/backend/application/ai_timing/separation.py
+++ b/src/strange_uta_game/backend/application/ai_timing/separation.py
@@ -13,13 +13,141 @@ import json
 import subprocess
 from collections import deque
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
 ProgressFn = Callable[[str, int, str], None]
 CancelFn = Callable[[], bool]
 
 SEPARATION_MODEL = "UVR-MDX-NET-Inst_HQ_3.onnx"
 VOCAL_STEM = "人声"
+
+# ── 分离模型预下载（缺文件时用镜像补，避免 audio-separator 直连 GitHub）──
+#
+# audio-separator 的下载判据是「文件已存在就永不下载、也不校验」——因此
+# 我们预先用 SUG 的多源接力（官方直连 + gh-proxy 镜像 + 代理）把下面这些
+# 文件拉进 audio-separator 的 model_file_dir（即模型根 model_root），它检测
+# 到存在即跳过，全程不碰 GitHub。URL 与 audio-separator 0.47.0 实际访问的
+# 完全一致（域名/路径镜像）。
+SEPARATION_MODEL_URL = (
+    "https://github.com/TRvlvr/model_repo/releases/download/"
+    "all_public_uvr_models/UVR-MDX-NET-Inst_HQ_3.onnx"
+)
+# audio-separator 依次寻找的元数据/模型清单小文件（application_data 仓库 raw）。
+# 注意 mdx/vr 两张 model_data 来自同一 repo 的不同子路径，但 audio-separator
+# 会把它们各自另存为 mdx_model_data.json / vr_model_data.json。
+SEPARATION_MODEL_FILES: "list[tuple[str, str]]" = [
+    (SEPARATION_MODEL, SEPARATION_MODEL_URL),
+    (
+        "download_checks.json",
+        "https://raw.githubusercontent.com/TRvlvr/application_data/main/"
+        "filelists/download_checks.json",
+    ),
+    (
+        "mdx_model_data.json",
+        "https://raw.githubusercontent.com/TRvlvr/application_data/main/"
+        "mdx_model_data/model_data_new.json",
+    ),
+    (
+        "vr_model_data.json",
+        "https://raw.githubusercontent.com/TRvlvr/application_data/main/"
+        "vr_model_data/model_data_new.json",
+    ),
+]
+
+
+def _download_missing_model_files(
+    model_root,
+    *,
+    proxy: str = "",
+    progress: Optional[Callable[[str, int, str], None]] = None,
+    cancel: Optional[CancelFn] = None,
+) -> List[str]:
+    """把 model_file_dir 里缺失的分离模型文件补齐（镜像/代理接力）。
+
+    只下载缺失项；已存在（audio-separator 判定会跳过下载）不重拉。返回
+    本次实际下载的文件名列表。失败抛 AiTimingError（中文、可操作）。
+    即使本函数抛错，调用方也应让 audio-separator 自行官方下载兜底。
+    """
+    import os
+    import shutil
+
+    root = Path(model_root)
+    target = root  # 分离模型直接落在模型根（与 audio-separator model_file_dir 一致）
+    target.mkdir(parents=True, exist_ok=True)
+
+    from strange_uta_game.backend.application.ai_timing.runtime import (
+        AiRuntimeError,
+        _download_attempts,
+    )
+
+    downloaded: List[str] = []
+    progress = progress or (lambda _s, _p, _m: None)
+    cancel = cancel or (lambda: False)
+
+    for name, url in SEPARATION_MODEL_FILES:
+        if cancel():
+            raise AiRuntimeError("已取消")
+        dest = target / name
+        if dest.is_file():
+            continue  # 已存在：audio-separator 也不会重下
+        attempts = _download_attempts(url, proxy)
+        errors: List[str] = []
+        ok = False
+        # 原子写入：先写同目录 .part 再改名（与模型下载/AiCache 一致），
+        # 避免半成品被 audio-separator 当完整文件
+        import uuid as _uuid
+
+        part = target / f".{name}.{_uuid.uuid4().hex}.part"
+        import requests
+
+        try:
+            for cand_url, cand_proxies in attempts:
+                if cancel():
+                    raise AiRuntimeError("已取消")
+                try:
+                    with requests.get(
+                        cand_url,
+                        stream=True,
+                        timeout=(30, 60),
+                        proxies=cand_proxies,
+                    ) as resp:
+                        resp.raise_for_status()
+                        with part.open("wb") as fh:
+                            for chunk in resp.iter_content(chunk_size=1024 * 256):
+                                if cancel():
+                                    raise AiRuntimeError("已取消")
+                                if chunk:
+                                    fh.write(chunk)
+                    total = part.stat().st_size
+                    if total <= 0:
+                        raise RuntimeError("下载内容为空")
+                    shutil.move(str(part), str(dest))
+                    ok = True
+                    break
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(f"{cand_url}: {exc}")
+        finally:
+            try:
+                part.unlink(missing_ok=True)
+            except OSError:
+                pass
+        if not ok:
+            # 留给 audio-separator 官方下载兜底：不硬抛阻断分离主流程，
+            # 但记录日志。onnx 缺失时下一轮仍会尝试补齐。
+            from strange_uta_game.backend.application.ai_timing.ailog import ailog
+
+            ailog(
+                "separation",
+                f"分离模型预下载失败（{name}）：" + "；".join(errors[-3:]),
+            )
+            continue
+        downloaded.append(name)
+        progress(
+            "separation",
+            0,
+            _tr("已补齐分离模型文件 {name}").format(name=name),
+        )
+    return downloaded
 
 
 def _tr(s: str) -> str:
@@ -113,7 +241,7 @@ def ensure_separation_model(model_root) -> str:
     root = Path(model_root) if model_root else None
     if root is None or not root.is_dir():
         return ""
-    notes = []
+    notes: List[str] = []
     hashes = set()
     for name in _MODEL_DATA_JSONS:
         table = root / name
@@ -146,7 +274,7 @@ def ensure_separation_model(model_root) -> str:
                     "将在下次分离时重新下载"
                 )
             )
-    joined = "；".join(notes)
+    joined = "；".join(n for n in notes if n)
     if joined:
         from strange_uta_game.backend.application.ai_timing.ailog import ailog
 
@@ -230,7 +358,8 @@ class StandaloneVocalSeparator:
             零参 callable（惰性读取：安装/修复完成后路径才写入设置，
             同一次弹窗会话内 prober 必须能立即反映新值）。空 = 当前
             解释器，仅在主环境恰好装有 audio-separator 时可用。
-        model_root: 统一模型根（分离模型与对齐模型同源）。
+        model_root: 统一模型根（分离模型与对齐模型同源，audio-separator 的
+            model_file_dir 即此根）。
         proxy: 传给分离子进程的网络代理 URL；模型首次使用需从
             GitHub 下载，代理设置必须随之注入子进程环境。
         embedded: 嵌入式运行（工作台宿主）。FFmpeg 解析来源不变
@@ -257,6 +386,16 @@ class StandaloneVocalSeparator:
 
     def identity(self) -> dict:
         return {"model": SEPARATION_MODEL, "stem": VOCAL_STEM, "params": {}}
+
+    def _download_missing_model_files(
+        self,
+        progress: Optional[Callable[[str, int, str], None]] = None,
+        cancel: Optional[CancelFn] = None,
+    ) -> List[str]:
+        """补齐 model_file_dir 里缺失的分离模型文件（走 self._proxy 镜像接力）。"""
+        return _download_missing_model_files(
+            self._model_root, proxy=self._proxy, progress=progress, cancel=cancel
+        )
 
     def available(self) -> bool:
         python = self._python_exe()
@@ -313,6 +452,14 @@ class StandaloneVocalSeparator:
             "separation",
             f"人声分离开始：source={source.name} python={python}",
         )
+        # 模型预下载（镜像接力，缺失才补）：audio-separator「文件在即跳过」
+        # —— 我们用 SUG 多源（官方 + gh-proxy + 代理）先把模型文件拉齐，
+        # 避免 audio-separator 直连 GitHub。best-effort：失败不阻断，交给
+        # audio-separator 自身官方下载兜底。
+        try:
+            self._download_missing_model_files()
+        except Exception as exc:  # noqa: BLE001
+            ailog("separation", f"分离模型预下载异常（继续走 audio-separator）：{exc}")
         # 模型体检自愈：残缺下载在子进程查表处必败且永不自愈
         note = ensure_separation_model(self._model_root)
         if note:
@@ -565,8 +712,11 @@ __all__ = [
     "StandaloneVocalSeparator",
     "host_first_separation",
     "SEPARATION_MODEL",
+    "SEPARATION_MODEL_URL",
+    "SEPARATION_MODEL_FILES",
     "VOCAL_STEM",
     "ffmpeg_missing_message",
     "resolve_ffmpeg_exe",
     "ensure_separation_model",
+    "_download_missing_model_files",
 ]

--- a/src/strange_uta_game/frontend/editor/ai_timing_dialog.py
+++ b/src/strange_uta_game/frontend/editor/ai_timing_dialog.py
@@ -403,13 +403,29 @@ class AiTimingDialog(QDialog):
         self._box_adv.contentLayout.addWidget(self.model_desc)
         mirror_row = QHBoxLayout()
         mirror_row.addWidget(BodyLabel(self.tr("下载镜像:"), content))
-        self.edit_mirror = LineEdit(content)
-        self.edit_mirror.setText(self._settings.download_mirror)
-        self.edit_mirror.setPlaceholderText(
-            self.tr("留空使用官方源，如 https://hf-mirror.com")
+        self.combo_mirror = ComboBox(content)
+        # 预设项 userData 存镜像端点 URL；「自定义 URL…」用 __custom__ 占位，
+        # 选中时下方展开 edit_mirror 输入框（下载镜像此前形同虚设：自由
+        # 文本框只写回设置，从不更新已建的 HfHubTransport 端点）
+        self.combo_mirror.addItem(
+            self.tr("官方（huggingface.co）"), userData=""
         )
-        mirror_row.addWidget(self.edit_mirror, 1)
+        self.combo_mirror.addItem(
+            self.tr("hf-mirror.com"), userData="https://hf-mirror.com"
+        )
+        self.combo_mirror.addItem(self.tr("自定义 URL…"), userData="__custom__")
+        mirror_row.addWidget(self.combo_mirror, 1)
         self._box_adv.contentLayout.addLayout(mirror_row)
+        self.edit_mirror = LineEdit(content)
+        self.edit_mirror.setPlaceholderText(
+            self.tr("输入镜像端点，如 https://hf-mirror.com")
+        )
+        self._box_adv.contentLayout.addWidget(self.edit_mirror)
+        # 先按当前设置同步选中，再连信号——避免初始 setCurrentIndex 触发
+        # 持久化（构造期写设置既多余又可能落到旧值上）
+        self._sync_mirror_ui()
+        self.combo_mirror.currentIndexChanged.connect(self._on_mirror_combo_changed)
+        self.edit_mirror.editingFinished.connect(self._on_mirror_custom_edited)
 
         # ── 存储位置（§3.2）：统一行样式——名称 + 省略路径 + 浏览 + 更改… ──
         self._box_store = FluentGroupBox(self.tr("存储位置"), content)
@@ -725,12 +741,58 @@ class AiTimingDialog(QDialog):
         self._settings.device = ("auto", "cpu", "cuda", "mps")[
             self.combo_device.currentIndex()
         ]
-        self._settings.download_mirror = self.edit_mirror.text().strip()
+        self._settings.download_mirror = self._mirror_value()
+        # 下载端点必须同步到已建的 transport，否则镜像形同虚设：transport
+        # 在弹窗构造时按当时设置固化 endpoint，改设置不改 transport 下载仍
+        # 走旧源（曾长期是纯摆设——填了只存配置不生效）
+        try:
+            self._download_service.set_endpoint(self._settings.download_mirror)
+        except Exception:
+            pass
         if self._save_settings is not None:
             try:
                 self._save_settings(self._settings)
             except Exception:
                 pass
+
+    # ── 下载镜像（预设 / 自定义）──
+
+    def _sync_mirror_ui(self) -> None:
+        """按当前 settings.download_mirror 同步 combo 选择与自定义输入框。"""
+        value = (self._settings.download_mirror or "").strip()
+        if not value:
+            self.combo_mirror.setCurrentIndex(0)
+            self.edit_mirror.clear()
+        elif value == "https://hf-mirror.com":
+            self.combo_mirror.setCurrentIndex(1)
+            self.edit_mirror.clear()
+        else:
+            # 其它端点（自定义）：选中自定义项并回填输入框
+            self.combo_mirror.setCurrentIndex(2)
+            self.edit_mirror.setText(value)
+        self._update_mirror_edit_visibility()
+
+    def _update_mirror_edit_visibility(self) -> None:
+        self.edit_mirror.setVisible(
+            self.combo_mirror.currentData() == "__custom__"
+        )
+
+    def _mirror_value(self) -> str:
+        """读当前镜像选择 → 端点 URL（空串 = 官方源）。"""
+        data = self.combo_mirror.currentData()
+        if data == "__custom__":
+            return self.edit_mirror.text().strip()
+        return str(data or "")
+
+    def _on_mirror_combo_changed(self, *_args) -> None:
+        # 弹层（RoundMenu）关闭栈内同步触发；切换仅改可见性 + 持久化，
+        # 不启动线程，直接同步处理安全（与模型下拉的延迟无关）
+        self._update_mirror_edit_visibility()
+        self._persist_settings()
+
+    def _on_mirror_custom_edited(self) -> None:
+        # 自定义 URL 输入结束（回车 / 失焦）→ 持久化并同步端点
+        self._persist_settings()
 
     MODEL_DESCRIPTIONS = {
         0: (
@@ -1408,7 +1470,8 @@ class AiTimingDialog(QDialog):
         self._settings.download_mirror = ""
         self.combo_model.setCurrentIndex(0)
         self.combo_device.setCurrentIndex(0)
-        self.edit_mirror.clear()
+        self.combo_mirror.setCurrentIndex(0)
+        self._update_mirror_edit_visibility()
         self._persist_settings()
         self.refresh()
 

--- a/tests/unit/application/test_ai_timing_models.py
+++ b/tests/unit/application/test_ai_timing_models.py
@@ -239,6 +239,49 @@ class TestModelDownloadService:
         with pytest.raises(ModelRegistryError, match="没有可下载的文件"):
             service.download("NextFire/empty", "wav2vec2")
 
+    def test_set_endpoint_forwards_to_supporting_transport(self):
+        """ModelDownloadService.set_endpoint 把端点转发给支持动态换端点的
+        transport（弹窗内改镜像后热更新，修复此前形同虚设的问题）。"""
+        calls = []
+
+        class _Supporting:
+            def set_endpoint(self, endpoint):
+                calls.append(endpoint)
+
+        service = ModelDownloadService(ModelRegistry(Path("x")), _Supporting())
+        service.set_endpoint("https://hf-mirror.com")
+        assert calls == ["https://hf-mirror.com"]
+
+    def test_set_endpoint_noop_for_non_supporting_transport(self):
+        """transport 无 set_endpoint（旧/自定义）时静默跳过，不崩。"""
+        service = ModelDownloadService(ModelRegistry(Path("x")), _FakeTransport())
+        service.set_endpoint("https://hf-mirror.com")  # 不应抛
+
+
+class TestHfHubTransportEndpoint:
+    def test_default_endpoint_is_official(self):
+        from strange_uta_game.backend.application.ai_timing.models import (
+            HfHubTransport,
+        )
+
+        t = HfHubTransport(endpoint="")
+        assert t._endpoint == "https://huggingface.co"
+
+    def test_set_endpoint_switches_and_defaults(self):
+        from strange_uta_game.backend.application.ai_timing.models import (
+            HfHubTransport,
+        )
+
+        t = HfHubTransport(endpoint="")
+        t.set_endpoint("https://hf-mirror.com")
+        assert t._endpoint == "https://hf-mirror.com"
+        # 空串回落官方源；末尾斜杠被去除（与构造行为一致）
+        t.set_endpoint("https://example.org/")
+        assert t._endpoint == "https://example.org"
+        t.set_endpoint("")
+        assert t._endpoint == "https://huggingface.co"
+
+
 
 class TestRuntimeProbe:
     def test_probe_current_interpreter(self):

--- a/tests/unit/application/test_ai_timing_separation.py
+++ b/tests/unit/application/test_ai_timing_separation.py
@@ -566,3 +566,78 @@ class TestHostFirstSeparation:
         assert follows is False and prober() is True
         out = executor(Path("s.flac"), lambda *a: None, lambda: False)
         assert out == Path("C:/builtin_vocal.wav")
+
+
+class TestSeparationModelPredownload:
+    """_download_missing_model_files：缺文件时镜像补齐到模型根，存在则跳过。
+
+    复现 audio-separator「文件在即跳过」判据——我们预先用多源（官方 +
+    gh-proxy + 代理）拉齐，避免其直连 GitHub。requests.get 被 mock。
+    """
+
+    @staticmethod
+    def _fake_resp(body: bytes = b"AA" * 1000):
+        class _R:
+            def raise_for_status(self):
+                pass
+
+            def iter_content(self, chunk_size=1024):
+                for i in range(0, len(body), chunk_size):
+                    yield body[i : i + chunk_size]
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        return _R()
+
+    def test_downloads_all_missing_to_root(self, tmp_path, monkeypatch):
+        import requests
+
+        monkeypatch.setattr(requests, "get", lambda *a, **k: self._fake_resp())
+        models = tmp_path / "models"
+        dl = sep_mod._download_missing_model_files(models, proxy="")
+        assert len(dl) == 4
+        for name, _ in sep_mod.SEPARATION_MODEL_FILES:
+            assert (models / name).is_file()  # 直接落在模型根
+        assert not [p for p in models.iterdir() if ".part" in p.name]
+
+    def test_existing_files_skipped_no_network(self, tmp_path, monkeypatch):
+        import requests
+
+        models = tmp_path / "models"
+        models.mkdir(parents=True, exist_ok=True)
+        for name, _ in sep_mod.SEPARATION_MODEL_FILES:
+            (models / name).write_bytes(b"present")
+        calls = []
+        monkeypatch.setattr(
+            requests, "get", lambda *a, **k: calls.append(a) or self._fake_resp()
+        )
+        dl = sep_mod._download_missing_model_files(models, proxy="")
+        assert dl == []
+        assert calls == []
+
+    def test_raw_url_gets_gh_proxy_mirror_candidates(self):
+        from strange_uta_game.backend.application.ai_timing.runtime import (
+            _github_mirror_candidates,
+        )
+
+        raw = (
+            "https://raw.githubusercontent.com/TRvlvr/application_data/main/"
+            "mdx_model_data/model_data_new.json"
+        )
+        cands = _github_mirror_candidates(raw)
+        assert cands
+        assert all("gh-proxy" in u and "raw.githubusercontent.com" in u for u in cands)
+
+    def test_github_release_url_gets_gh_proxy_mirror_candidates(self):
+        from strange_uta_game.backend.application.ai_timing.runtime import (
+            _github_mirror_candidates,
+        )
+
+        cands = _github_mirror_candidates(sep_mod.SEPARATION_MODEL_URL)
+        assert cands
+        assert all("gh-proxy" in u and "github.com/TRvlvr" in u for u in cands)
+

--- a/tests/unit/frontend/test_ai_timing_dialog.py
+++ b/tests/unit/frontend/test_ai_timing_dialog.py
@@ -802,3 +802,85 @@ class TestDefaultWidthFits:
                 overflow.append((need, have))
         assert overflow == [], f"内容超出视口: {overflow}"
         dialog.close()
+
+
+class TestDownloadMirrorApplied:
+    """下载镜像：改设置必须同步到 download_service 的 transport 端点。
+
+    回归：镜像此前形同虚设——transport 在弹窗构造时按当时设置固化 endpoint，
+    dialog 内改镜像只写配置、从不更新已建的 transport，下载仍走官方源。
+    """
+
+    class _SpyTransport:
+        def __init__(self):
+            self.endpoints = []
+
+        def list_files(self, repo_id, revision):
+            return []
+
+        def download_file(self, *a, **k):
+            raise RuntimeError("测试不执行下载")
+
+        def set_endpoint(self, endpoint):
+            self.endpoints.append(endpoint)
+
+    def _make(self, qapp, tmp_path, snapshot, transport):
+        from strange_uta_game.backend.application.ai_timing.models import (
+            ModelDownloadService,
+        )
+        from strange_uta_game.backend.application.ai_timing.runtime import (
+            AiRuntimeManager,
+        )
+        from strange_uta_game.frontend.editor.ai_timing_dialog import AiTimingDialog
+
+        registry = ModelRegistry(tmp_path / "models")
+        service = _FakeService(snapshot)
+        dialog = AiTimingDialog(
+            project=_project(),
+            audio_path=str(tmp_path / "song.flac"),
+            service=service,
+            settings=AiTimingSettings(),
+            registry=registry,
+            runtime=AiRuntimeManager(),
+            download_service=ModelDownloadService(registry, transport),
+            on_applied=lambda *a: None,
+            parent=None,
+        )
+        return dialog
+
+    def test_persist_applies_selected_preset(self, qapp, tmp_path):
+        snap = _ready_snapshot()
+        transport = self._SpyTransport()
+        dialog = self._make(qapp, tmp_path, snap, transport)
+        TestPathChangeAppliesImmediately._wait_initial_refresh(qapp, dialog)
+        # 初始构造用空设置 → 官方源（不应记录任何 set_endpoint 副作用之外的
+        # 值；_sync_mirror_ui 在构造期不触发 persist，故此时为空）
+        # 选 hf-mirror.com 预设 → persist 时端点必须同步
+        dialog.combo_mirror.setCurrentIndex(1)
+        dialog._persist_settings()
+        assert dialog._settings.download_mirror == "https://hf-mirror.com"
+        assert transport.endpoints[-1] == "https://hf-mirror.com"
+
+    def test_custom_url_applied_and_custom_edit_shown(self, qapp, tmp_path):
+        snap = _ready_snapshot()
+        transport = self._SpyTransport()
+        dialog = self._make(qapp, tmp_path, snap, transport)
+        TestPathChangeAppliesImmediately._wait_initial_refresh(qapp, dialog)
+        dialog.combo_mirror.setCurrentIndex(2)  # 自定义
+        assert dialog.edit_mirror.isVisible()  # 自定义时输入框展开
+        dialog.edit_mirror.setText("https://custom.example.org")
+        dialog._persist_settings()
+        assert dialog._settings.download_mirror == "https://custom.example.org"
+        assert transport.endpoints[-1] == "https://custom.example.org"
+
+    def test_reset_returns_to_official(self, qapp, tmp_path):
+        snap = _ready_snapshot()
+        transport = self._SpyTransport()
+        dialog = self._make(qapp, tmp_path, snap, transport)
+        TestPathChangeAppliesImmediately._wait_initial_refresh(qapp, dialog)
+        dialog.combo_mirror.setCurrentIndex(1)
+        dialog._persist_settings()
+        dialog._on_reset_settings()
+        assert dialog._settings.download_mirror == ""
+        assert dialog.combo_mirror.currentIndex() == 0
+


### PR DESCRIPTION
## 背景

围绕 AI 打轴（阶段 F/G）做的几处修复，均为源码/打包部署共性问题。

和<https://github.com/karaoke-studio/StrangeUtaGame/pull/98>相同，但回退了关于模型位置的修改。

## 改动

### 1. 修复「下载镜像」对 HF 对齐模型完全不生效
根因：`HfHubTransport._endpoint` 在弹窗构造时按当时设置固化一次；弹窗里改
镜像只写回配置，从不更新已建的 transport → 下载永远走官方源。

- `models.py`：`HfHubTransport` 新增 `set_endpoint()`（空串回落官方源）；
  `ModelDownloadService` 新增 `set_endpoint()`（转发给 transport，`hasattr`
  防御自定义 transport）。
- `ai_timing_dialog.py`：`_persist_settings` 写入镜像后同步
  `download_service.set_endpoint()`；把「下载镜像」从纯摆设的自由文本框改为
  「预设（官方 / hf-mirror.com）+ 自定义 URL」，新增同步/重置逻辑。

### 2. audio-separator 分离模型镜像预下载（缺文件才补，落在模型根）
audio-separator 的下载判据是「文件已存在就永不下载、也不校验」——因此
`separation.py` 在分离启动前用 SUG 多源接力（官方直连 + gh-proxy + 代理）
把 audio-separator 需要的 4 个文件补齐到模型根（UVR onnx + download_checks
+ mdx/vr 数据表），缺失才下载，best-effort（失败交给 audio-separator 自身
官方下载兜底），避免它直连 GitHub。

- `separation.py`：新增 `SEPARATION_MODEL_URL` / `SEPARATION_MODEL_FILES`
  与 `_download_missing_model_files()`（原子 `.part` 写入），并在
  `StandaloneVocalSeparator.separate()` 启动前调用。
- `runtime.py`：`_github_mirror_candidates` 扩展支持
  `raw.githubusercontent.com`（与 `github.com` 同用 gh-proxy 前缀整体包装）。

> 说明：audio-separator 模型仍直接落在模型根（与 audio-separator 默认的
> model_file_dir 一致），未做目录移动。

### 3. AI 运行依赖清单外置（源码部署可直接复用现有解释器）
- 新增 `requirements-ai.txt`：内容对应 `runtime.py` 的 `RUNTIME_REQUIREMENTS`
  （torch / transformers==5.15.0 / audio-separator[cpu] / librosa==0.10.2.post1
  等，+ CUDA 追加说明）。
- `README_DEV.md`：说明源码部署者 `pip install -r requirements.txt -r
  requirements-ai.txt` 后 probe 即可复用当前解释器，不必新建隔离 venv。

### 4. `.gitignore`
- 加入 `ai_models/`（AI 模型需额外下载，不入库）。

## 测试

- 补了 `models` / `separation` / `dialog` 三个测试文件用例：`set_endpoint`
  热更新、镜像预设同步、缺失模型预下载（落到根）、raw/github 的 gh-proxy
  镜像候选。